### PR TITLE
fix: merge migrations in graphql schema

### DIFF
--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -60,9 +60,6 @@ type User {
     updated_at: DateTime
 }
 
-"""
-Create a new user.
-"""
 type Mutation {
     "Create a new user"
     createUser(user: CreateUserInput! @spread): User! @create

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -64,13 +64,12 @@ type User {
 Create a new user.
 """
 type Mutation {
+    "Create a new user"
     createUser(user: CreateUserInput! @spread): User! @create
-}
 
-type Mutation {
-  "Log in to a new session and get the user."
-  login(email: String!, password: String!): User!
+    "Log in to a new session and get the user."
+    login(email: String!, password: String!): User!
 
-  "Log out from the current session, showing the user one last time."
-  logout: User @guard
+    "Log out from the current session, showing the user one last time."
+    logout: User @guard
 }


### PR DESCRIPTION
#97 introduced a regression into the graphql schema file.  (multiple root types aren't allowed).  This PR merges the two into a single root type.
