### PR TITLE
feat: extend graphql with user roles

### DIFF
--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -95,7 +95,7 @@ type User {
     username: String!
     created_at: DateTime!
     updated_at: DateTime
-    roles: [Role]
+    roles: [Role!]!
 }
 
 type Mutation {

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -15,6 +15,7 @@ type Query {
     "Validate details of a new user.  Returns true if supplied user fields would be valid."
     validateNewUser(user: ValidateNewUserInput): Boolean @returnTrue
 
+    "Return pre-defined user roles in the application"
     role(id: ID @eq): Role @find
 }
 

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -73,6 +73,9 @@ input CreateUserInput {
         @hash
 }
 
+"""
+A user role for permissions
+"""
 type Role {
     id: ID!
     name: String!

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -14,6 +14,8 @@ type Query {
 
     "Validate details of a new user.  Returns true if supplied user fields would be valid."
     validateNewUser(user: ValidateNewUserInput): Boolean @returnTrue
+
+    role(id: ID @eq): Role @find
 }
 
 "Validate the availability of username and email via the validateNewUser query"
@@ -71,6 +73,14 @@ input CreateUserInput {
         @hash
 }
 
+type Role {
+    id: ID!
+    name: String!
+    guard_name: String!
+    created_at: DateTime
+    updated_at: DateTime
+}
+
 """
 A user account.
 """
@@ -81,6 +91,7 @@ type User {
     username: String!
     created_at: DateTime!
     updated_at: DateTime
+    roles: [Role]
 }
 
 type Mutation {

--- a/backend/tests/Feature/UserPermissionsTest.php
+++ b/backend/tests/Feature/UserPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -11,7 +12,7 @@ use App\Models\Permission;
 
 class UserPermissionsTest extends TestCase
 {
-    use RefreshDatabase;
+    use MakesGraphQLRequests, RefreshDatabase;
 
     private $test_permission = 'test permission';
     private $test_user_role = 'Test User Role';
@@ -125,5 +126,83 @@ class UserPermissionsTest extends TestCase
         $test_role->givePermissionTo($this->test_permission);
         $user->assignRole(Role::PUBLICATION_ADMINISTRATOR);
         $this->assertFalse($user->can($this->test_permission));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRoleIsQueryableFromUserCreatedViaLighthouse()
+    {
+        $createUserResponse = $this->graphQL(
+            'mutation {
+                createUser(user: {
+                    email: "brandnew@gmail.com",
+                    password: "KajSu8viptUrz&",
+                    username: "testusername",
+                    name: "Test Name"
+                }) {
+                    id
+                    name
+                    username
+                }
+            }'
+        );
+        $test_role = Role::factory()->create([
+            'name' => $this->test_user_role
+        ]);
+        $user = User::where('username','testusername')->first();
+        $user->assignRole($this->test_user_role);
+        $getUserResponse = $this->graphQL(
+            'query getUser($id: ID) {
+                user(id: $id) {
+                    id
+                    name
+                    roles {
+                        id
+                        name
+                    }
+                }
+            }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
+        );
+        $test_role_id = (string) $test_role->id;
+        $expected_array = [
+            0 => [
+                'id' => $test_role_id,
+                'name' => 'Test User Role'
+            ]
+        ];
+        $getUserResponse->assertJsonPath("data.user.roles", $expected_array);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRoleIsQueryableFromUserCreatedViaFactory()
+    {
+        $test_role = Role::factory()->create([
+            'name' => $this->test_user_role
+        ]);
+        $user = User::factory()->create();
+        $user->assignRole($this->test_user_role);
+        $response = $this->graphQL(
+            'query getUser($id: ID) {
+                user(id: $id) {
+                    id
+                    name
+                    roles {
+                        id
+                        name
+                    }
+                }
+            }', ['id' => $user->id]
+        );
+        $test_role_id = (string) $test_role->id;
+        $expected_array = [
+            0 => [
+                'id' => $test_role_id,
+                'name' => 'Test User Role'
+            ]
+        ];
+        $response->assertJsonPath("data.user.roles", $expected_array);
     }
 }

--- a/backend/tests/Feature/UserPermissionsTest.php
+++ b/backend/tests/Feature/UserPermissionsTest.php
@@ -131,7 +131,7 @@ class UserPermissionsTest extends TestCase
     /**
      * @return void
      */
-    public function testRoleIsQueryableFromUserCreatedViaLighthouse()
+    public function testRoleForUserCreatedViaLighthouseIsQueryableFromGraphqlEndpoint()
     {
         $createUserResponse = $this->graphQL(
             'mutation {
@@ -177,7 +177,7 @@ class UserPermissionsTest extends TestCase
     /**
      * @return void
      */
-    public function testRoleIsQueryableFromUserCreatedViaFactory()
+    public function testRoleForUserCreatedViaFactoryIsQueryableFromGraphqlEndpoint()
     {
         $test_role = Role::factory()->create([
             'name' => $this->test_user_role

--- a/backend/tests/Feature/UserPermissionsTest.php
+++ b/backend/tests/Feature/UserPermissionsTest.php
@@ -164,10 +164,9 @@ class UserPermissionsTest extends TestCase
                 }
             }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
         );
-        $test_role_id = (string) $test_role->id;
         $expected_array = [
             0 => [
-                'id' => $test_role_id,
+                'id' => (string) $test_role->id,
                 'name' => 'Test User Role'
             ]
         ];
@@ -196,10 +195,9 @@ class UserPermissionsTest extends TestCase
                 }
             }', ['id' => $user->id]
         );
-        $test_role_id = (string) $test_role->id;
         $expected_array = [
             0 => [
-                'id' => $test_role_id,
+                'id' => (string) $test_role->id,
                 'name' => 'Test User Role'
             ]
         ];
@@ -224,8 +222,7 @@ class UserPermissionsTest extends TestCase
                 }
             }', ['id' => $user->id]
         );
-        $expected_array = [];
-        $response->assertJsonPath("data.user.roles", $expected_array);
+        $response->assertJsonPath("data.user.roles", []);
     }
 
     /**
@@ -259,7 +256,6 @@ class UserPermissionsTest extends TestCase
                 }
             }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
         );
-        $expected_array = [];
-        $getUserResponse->assertJsonPath("data.user.roles", $expected_array);
+        $getUserResponse->assertJsonPath("data.user.roles", []);
     }
 }

--- a/backend/tests/Feature/UserPermissionsTest.php
+++ b/backend/tests/Feature/UserPermissionsTest.php
@@ -131,52 +131,7 @@ class UserPermissionsTest extends TestCase
     /**
      * @return void
      */
-    public function testRoleForUserCreatedViaLighthouseIsQueryableFromGraphqlEndpoint()
-    {
-        $createUserResponse = $this->graphQL(
-            'mutation {
-                createUser(user: {
-                    email: "brandnew@gmail.com",
-                    password: "KajSu8viptUrz&",
-                    username: "testusername",
-                    name: "Test Name"
-                }) {
-                    id
-                    name
-                    username
-                }
-            }'
-        );
-        $test_role = Role::factory()->create([
-            'name' => $this->test_user_role
-        ]);
-        $user = User::where('username','testusername')->first();
-        $user->assignRole($this->test_user_role);
-        $getUserResponse = $this->graphQL(
-            'query getUser($id: ID) {
-                user(id: $id) {
-                    id
-                    name
-                    roles {
-                        id
-                        name
-                    }
-                }
-            }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
-        );
-        $expected_array = [
-            0 => [
-                'id' => (string) $test_role->id,
-                'name' => 'Test User Role'
-            ]
-        ];
-        $getUserResponse->assertJsonPath("data.user.roles", $expected_array);
-    }
-
-    /**
-     * @return void
-     */
-    public function testRoleForUserCreatedViaFactoryIsQueryableFromGraphqlEndpoint()
+    public function testRoleForUserIsQueryableFromGraphqlEndpoint()
     {
         $test_role = Role::factory()->create([
             'name' => $this->test_user_role
@@ -207,7 +162,7 @@ class UserPermissionsTest extends TestCase
     /**
      * @return void
      */
-    public function testUserCreatedViaFactoryWithNoRoleReturnsAnEmptyArrayWhenQueriedFromGraphqlEndpoint()
+    public function testUserWithNoRoleReturnsAnEmptyArrayWhenQueriedFromGraphqlEndpoint()
     {
         $user = User::factory()->create();
         $response = $this->graphQL(
@@ -223,39 +178,5 @@ class UserPermissionsTest extends TestCase
             }', ['id' => $user->id]
         );
         $response->assertJsonPath("data.user.roles", []);
-    }
-
-    /**
-     * @return void
-     */
-    public function testUserCreatedViaLighthouseWithNoRoleReturnsAnEmptyArrayWhenQueriedFromGraphqlEndpoint()
-    {
-        $createUserResponse = $this->graphQL(
-            'mutation {
-                createUser(user: {
-                    email: "brandnew@gmail.com",
-                    password: "KajSu8viptUrz&",
-                    username: "testusername",
-                    name: "Test Name"
-                }) {
-                    id
-                    name
-                    username
-                }
-            }'
-        );
-        $getUserResponse = $this->graphQL(
-            'query getUser($id: ID) {
-                user(id: $id) {
-                    id
-                    name
-                    roles {
-                        id
-                        name
-                    }
-                }
-            }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
-        );
-        $getUserResponse->assertJsonPath("data.user.roles", []);
     }
 }

--- a/backend/tests/Feature/UserPermissionsTest.php
+++ b/backend/tests/Feature/UserPermissionsTest.php
@@ -205,4 +205,61 @@ class UserPermissionsTest extends TestCase
         ];
         $response->assertJsonPath("data.user.roles", $expected_array);
     }
+
+    /**
+     * @return void
+     */
+    public function testUserCreatedViaFactoryWithNoRoleReturnsAnEmptyArrayWhenQueriedFromGraphqlEndpoint()
+    {
+        $user = User::factory()->create();
+        $response = $this->graphQL(
+            'query getUser($id: ID) {
+                user(id: $id) {
+                    id
+                    name
+                    roles {
+                        id
+                        name
+                    }
+                }
+            }', ['id' => $user->id]
+        );
+        $expected_array = [];
+        $response->assertJsonPath("data.user.roles", $expected_array);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUserCreatedViaLighthouseWithNoRoleReturnsAnEmptyArrayWhenQueriedFromGraphqlEndpoint()
+    {
+        $createUserResponse = $this->graphQL(
+            'mutation {
+                createUser(user: {
+                    email: "brandnew@gmail.com",
+                    password: "KajSu8viptUrz&",
+                    username: "testusername",
+                    name: "Test Name"
+                }) {
+                    id
+                    name
+                    username
+                }
+            }'
+        );
+        $getUserResponse = $this->graphQL(
+            'query getUser($id: ID) {
+                user(id: $id) {
+                    id
+                    name
+                    roles {
+                        id
+                        name
+                    }
+                }
+            }', ['id' => $createUserResponse["data"]["createUser"]["id"]]
+        );
+        $expected_array = [];
+        $getUserResponse->assertJsonPath("data.user.roles", $expected_array);
+    }
 }


### PR DESCRIPTION
This PR extends the GraphQL endpoint with user roles.