### PR TITLE
feat: implement email verification backend

### DIFF
--- a/backend/app/Exceptions/ClientException.php
+++ b/backend/app/Exceptions/ClientException.php
@@ -10,6 +10,13 @@ class ClientException extends Exception implements RendersErrorsExtensions
     public $clientCode;
     public $category;
 
+    /**
+     * Construct a client safe exception.
+     *
+     * @param string $message Human readable error message.
+     * @param string $category Application category.
+     * @param string $clientCode Token for client code to match on for error message generation.
+     */
     public function __construct(string $message, string $category = null, string $clientCode)
     {
         $this->category = $category ?? 'unknown';

--- a/backend/app/Exceptions/ClientException.php
+++ b/backend/app/Exceptions/ClientException.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Nuwave\Lighthouse\Exceptions\RendersErrorsExtensions;
+
+class ClientException extends Exception implements RendersErrorsExtensions
+{
+    public $clientCode;
+    public $category;
+
+    public function __construct(string $message, string $category = null, string $clientCode)
+    {
+        $this->category = $category ?? 'unknown';
+        $this->clientCode = $clientCode ?? 'UNKNOWN';
+        parent::__construct($message);
+    }
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @api
+     * @return bool
+     */
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     *
+     * @api
+     * @return string
+     */
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+     /**
+     * Return the content that is put in the "extensions" part
+     * of the returned error.
+     *
+     * @return array
+     */
+     public function extensionsContent(): array
+     {
+         return [
+             'code' => strtoupper($this->clientCode)
+         ];
+     }
+}

--- a/backend/app/GraphQL/Mutations/VerifyEmail.php
+++ b/backend/app/GraphQL/Mutations/VerifyEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\ClientException;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
+
+class VerifyEmail
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $user = Auth::user();
+        $now = Carbon::now()->timestamp;
+        if ($now > $args['expires']) {
+            throw new ClientException('Token Expired', 'emailVerification', 'TOKEN_EXPIRED');
+        }
+
+        if (!$user->verifyEmailToken($args['token'], $args['expires'])) {
+            throw new ClientException('Invalid token', 'emailVerification', 'TOKEN_INVALID');
+        }
+
+        $user->markEmailAsVerified();
+
+        return $user;
+
+        
+
+    }
+}

--- a/backend/app/GraphQL/Mutations/VerifyEmail.php
+++ b/backend/app/GraphQL/Mutations/VerifyEmail.php
@@ -40,8 +40,16 @@ class VerifyEmail
      */
     public function send($_, array $args)
     {
-        $user = User::find($args['id']);
+        $user = Auth::user();
+        
+        if (!empty($args['id'])) {
+            //TODO: Add permissions check to allow admin users to send email based on UPDATE_USERS permission.
+            if ($args['id'] != $user->id ) {
+                throw new ClientException('Sending verification for another user is not implemented.', 'emailVerification', 'NOT_IMPLEMENTED');
+            }
 
+        }
+        
         if (!$user) {
             throw new ClientException('Not Found', 'emailVerification', 'NOT_FOUND');
         }

--- a/backend/app/GraphQL/Mutations/VerifyEmail.php
+++ b/backend/app/GraphQL/Mutations/VerifyEmail.php
@@ -3,7 +3,6 @@
 namespace App\GraphQL\Mutations;
 
 use App\Exceptions\ClientException;
-use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -24,6 +25,10 @@ class AuthServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPolicies();
+
+        VerifyEmail::$createUrlCallback = function ($notifiable) {
+            return $notifiable->getEmailVerificationUrl();
+        };
 
         //
     }

--- a/backend/config/mail.php
+++ b/backend/config/mail.php
@@ -53,6 +53,13 @@ return [
             'transport' => 'smtp',
             'host' => explode(':', env('MH_SENDMAIL_SMTP_ADDR', 'sendmailhog:1025'))[0],
             'port' => explode(':', env('MH_SENDMAIL_SMTP_ADDR', 'sendmailhog:1025'))[1],
+        ],
+        'log' => [
+            'transport' => 'log',
+            'channel' => 'stack'
+        ],
+        'array' => [
+            'transport' => 'array'
         ]
     ],
 

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -108,7 +108,21 @@ type Mutation {
         @create
         @event(dispatch: "Illuminate\\Auth\\Events\\Registered")
 
-    verifyEmail(token: String!, expires: String!): User! @guard
+    "Verify the currently logged in user's email address"
+    verifyEmail(
+        "Token supplied to the user via email"
+        token: String!
+
+        "Token expiration as a UNIX epoch timestamp"
+        expires: String!
+    ): User!
+        @guard
+        @field(resolver: "App\\GraphQL\\Mutations\\VerifyEmail@verify")
+
+    "(Re)send a verification email to a user."
+    sendEmailVerification(id: ID!): User!
+        @guard
+        @field(resolver: "App\\GraphQL\\Mutations\\VerifyEmail@send")
 
     "Log in to a new session and get the user."
     login(email: String!, password: String!): User!

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -119,8 +119,11 @@ type Mutation {
         @guard
         @field(resolver: "App\\GraphQL\\Mutations\\VerifyEmail@verify")
 
-    "(Re)send a verification email to a user."
-    sendEmailVerification(id: ID!): User!
+    "(Re)send a verification email to a user.  "
+    sendEmailVerification(
+        "User to resend verification for. If not supplied, defaults to the current user."
+        id: ID
+    ): User!
         @guard
         @field(resolver: "App\\GraphQL\\Mutations\\VerifyEmail@send")
 

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -17,7 +17,7 @@ type Query {
 
     "Return information about the currently logged in user"
     currentUser: User @auth
-    
+
     "Return pre-defined user roles in the application"
     role(id: ID @eq): Role @find
 }
@@ -98,12 +98,17 @@ type User {
     username: String!
     created_at: DateTime!
     updated_at: DateTime
+    email_verified_at: DateTime
     roles: [Role!]!
 }
 
 type Mutation {
     "Create a new user"
-    createUser(user: CreateUserInput! @spread): User! @create
+    createUser(user: CreateUserInput! @spread): User!
+        @create
+        @event(dispatch: "Illuminate\\Auth\\Events\\Registered")
+
+    verifyEmail(token: String!, expires: String!): User! @guard
 
     "Log in to a new session and get the user."
     login(email: String!, password: String!): User!

--- a/backend/tests/Feature/VerifyEmailTest.php
+++ b/backend/tests/Feature/VerifyEmailTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Notification;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+
+class VerifyEmailTest extends TestCase
+{
+    use RefreshDatabase, MakesGraphQLRequests;
+    
+
+    /**
+     * @return void
+     */
+    public function setUp(): void {
+        $testNow = Carbon::create(2021, 01, 15, 12, 30, 00);
+        Carbon::setTestNow($testNow);
+
+        parent::setUp();
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void {
+        Carbon::setTestNow(null);
+
+        parent::tearDown();
+    }
+    /**
+     * Call the verifyEmail graphql mutation
+     *
+     * @param array $variables
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function callVerifyEmailEndpoint(array $variables): \Illuminate\Testing\TestResponse {
+        return $this->graphQL('
+            mutation VerifyEmail($token: String!, $expires: String!) {
+                verifyEmail(token: $token, expires: $expires) {
+                    id
+                }
+            }
+        ', $variables);
+    }
+
+    /**
+     * Call createUser graphql mutation
+     *
+     * @param array $variables
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function callCreateUserEndpoint(array $variables): \Illuminate\Testing\TestResponse {
+        return $this->graphQL(
+            'mutation CreateUser($username: String! $email: String! $name: String $password: String!) {
+                createUser(user: { username: $username email: $email name: $name password: $password}) {
+                    username
+                    id
+                    name
+                    email
+                }
+            }', $variables);
+
+    }
+
+    /**
+     * @return void
+     */
+    public function testEmailVerificationSent(): void {
+        Notification::fake();
+
+        $testUser = User::factory()->make(['email' => 'mesh@msu.edu']);
+
+        $response = $this->callCreateUserEndpoint($testUser->makeVisible('password')->attributesToArray());
+        $response->assertJsonPath("data.createUser.username", $testUser->username);
+        
+        $user = User::find(Arr::get($response, 'data.createUser.id'));
+        $this->assertNotNull($user);
+
+        Notification::assertSentTo( [$user], VerifyEmail::class);
+    }
+
+    public function testEmailVerificationSentOnEmailUpdate(): void {
+        Notification::fake();
+
+        $testUser = User::factory()->create(['email' => 'mesh@msu.edu']);
+
+        $testUser->email = 'mesh2@msu.edu';
+        $testUser->save();
+
+        Notification::assertSentTo( [$testUser], VerifyEmail::class);
+        $this->assertNull($testUser->email_verified_at);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCanVerifyEmail(): void {
+        $testUser = User::factory()->create(['email' => 'mesh@msu.edu']);
+        $expires = (string)Carbon::now()->addMinutes(10)->timestamp;
+        $hash = $testUser->makeEmailVerificationHash($expires);
+
+        $this->actingAs($testUser);
+        $response = $this->callVerifyEmailEndpoint(['token' => $hash, 'expires' => $expires]);
+        
+        $this->assertNotNull(Arr::get($response, 'data.verifyEmail'));
+        $this->assertNull(Arr::get($response, 'errors'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiredTokenFailsEmailVerification(): void {
+        $testUser = User::factory()->create(['email' => 'mesh@msu.edu']);
+        $expires = (string)Carbon::now()->subMinutes(61)->timestamp;
+        $hash = $testUser->makeEmailVerificationHash($expires);
+
+        $this->actingAs($testUser);
+        $response = $this->callVerifyEmailEndpoint(['token' => $hash, 'expires' => $expires]);
+
+        $response->assertJsonPath('errors.0.extensions.code', 'TOKEN_EXPIRED');
+    }
+
+    /**
+     * @return void
+     */
+    public function testInvalidTokenFailsEmailVerification(): void {
+        $testUser = User::factory()->create(['email' => 'mesh@msu.edu']);
+        $expires = (string)Carbon::now()->addMinutes(10)->timestamp;
+        $hash = 'aninvalidhash';
+
+        $this->actingAs($testUser);
+        $response = $this->callVerifyEmailEndpoint(['token' => $hash, 'expires' => $expires]);
+
+        $response->assertJsonPath('errors.0.extensions.code', 'TOKEN_INVALID');
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresCannotBeManipulated(): void {
+        $testUser = User::factory()->create(['email' => 'mesh@msu.edu']);
+        $expires = (string)Carbon::now()->subMinutes(61)->timestamp; // Create an expired hash
+        $hash = $testUser->makeEmailVerificationHash($expires);
+
+        $invalidExpires = (string)Carbon::now()->addMinutes(10)->timestamp;
+        $this->actingAs($testUser);
+        $response = $this->callVerifyEmailEndpoint(['token' => $hash, 'expires' => $invalidExpires]);
+
+        $response->assertJsonPath('errors.0.extensions.code', 'TOKEN_INVALID');
+    }
+}


### PR DESCRIPTION
Does what it says on the tin.  Probably the best way to validate this PR is to check the unit tests.

To confirm the email notification is working:
- `lando extras enable mailhog`
- `lando rebuild -y`
- `lando start` (if needed)
- Visit https://ccr.lndo.site/register and create a new account
- Visit https://mailhog.ccr.lndo.site/ and see that the email was sent.

**Note: This is only the backend functionality.  Visiting the link contained in the email will not do anything at the moment**
I'm just breaking #87 into multiple PR's to keep them a little more reviewable.