### PR TITLE
feat: Add user search to GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ data/
 node_modules/
 backend/vendor/**/*
 /vendor/
+/backend/storage/

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -127,4 +127,18 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return hash_equals($this->makeEmailVerificationHash($expires), $token);
     }
+
+    /**
+     * Get the indexable data array for the model.
+     *
+     * @return array
+     */
+    public function toSearchableArray()
+    {
+        $array = $this->toArray();
+
+        // Customize array...
+
+        return $array;
+    }
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -11,6 +11,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Config;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use Laravel\Scout\Searchable;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -18,6 +19,7 @@ class User extends Authenticatable implements MustVerifyEmail
     use Notifiable;
     use HasApiTokens;
     use HasRoles;
+    use Searchable;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -10,8 +10,8 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Config;
 use Laravel\Sanctum\HasApiTokens;
-use Spatie\Permission\Traits\HasRoles;
 use Laravel\Scout\Searchable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements MustVerifyEmail
 {

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -129,7 +129,15 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
-     * Get the indexable data array for the model.
+     * Get the indexable data array for the model. Currently:
+     *
+     *     username
+     *     name
+     *     email
+     *     email_verified_at
+     *     updated_at
+     *     created_at
+     *     id
      *
      * @return array
      */
@@ -138,6 +146,7 @@ class User extends Authenticatable implements MustVerifyEmail
         $array = $this->toArray();
 
         // Customize array...
+        unset($array['profile_metadata']);
 
         return $array;
     }

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -19,7 +19,8 @@
         "laravel/tinker": "^2.5",
         "nuwave/lighthouse": "^5.1",
         "olssonm/l5-zxcvbn": "^4.4",
-        "spatie/laravel-permission": "^3.18"
+        "spatie/laravel-permission": "^3.18",
+        "teamtnt/laravel-scout-tntsearch-driver": "^11.2"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -15,6 +15,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
         "laravel/sanctum": "^2.8",
+        "laravel/scout": "^8.6",
         "laravel/tinker": "^2.5",
         "nuwave/lighthouse": "^5.1",
         "olssonm/l5-zxcvbn": "^4.4",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43acc331611ec6c6a70cd6a2699c6b6f",
+    "content-hash": "69d72693ea00465198c26b37e9ed174f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1654,6 +1654,75 @@
                 "source": "https://github.com/laravel/sanctum"
             },
             "time": "2021-01-26T19:47:38+00:00"
+        },
+        {
+            "name": "laravel/scout",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/scout.git",
+                "reference": "54070f7b68fed15f25e61e68884c4110496b8aa1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/54070f7b68fed15f25e61e68884c4110496b8aa1",
+                "reference": "54070f7b68fed15f25e61e68884c4110496b8aa1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0",
+                "illuminate/database": "^6.0|^7.0|^8.0",
+                "illuminate/http": "^6.0|^7.0|^8.0",
+                "illuminate/pagination": "^6.0|^7.0|^8.0",
+                "illuminate/queue": "^6.0|^7.0|^8.0",
+                "illuminate/support": "^6.0|^7.0|^8.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^8.0|^9.3"
+            },
+            "suggest": {
+                "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^2.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Scout\\ScoutServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Scout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Scout provides a driver based solution to searching your Eloquent models.",
+            "keywords": [
+                "algolia",
+                "laravel",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/scout/issues",
+                "source": "https://github.com/laravel/scout"
+            },
+            "time": "2021-01-19T15:30:52+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69d72693ea00465198c26b37e9ed174f",
+    "content-hash": "13f4c47296216f046d7b6053a8ca0555",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5537,6 +5537,154 @@
                 }
             ],
             "time": "2021-01-27T10:15:41+00:00"
+        },
+        {
+            "name": "teamtnt/laravel-scout-tntsearch-driver",
+            "version": "v11.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/teamtnt/laravel-scout-tntsearch-driver.git",
+                "reference": "d8c241c2315f494521fd3e6f3f1feb3396142d41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/teamtnt/laravel-scout-tntsearch-driver/zipball/d8c241c2315f494521fd3e6f3f1feb3396142d41",
+                "reference": "d8c241c2315f494521fd3e6f3f1feb3396142d41",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "~5.4|^6.0|^7.0|^8.0",
+                "illuminate/contracts": "~5.4|^6.0|^7.0|^8.0",
+                "illuminate/pagination": "~5.4|^6.0|^7.0|^8.0",
+                "illuminate/queue": "~5.4|^6.0|^7.0|^8.0",
+                "illuminate/support": "~5.4|^6.0|^7.0|^8.0",
+                "laravel/scout": "7.*|^8.0|^8.3",
+                "php": ">=7.1",
+                "teamtnt/tntsearch": "2.7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "suggest": {
+                "teamtnt/tntsearch": "Required to use the TNTSearch engine."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "TeamTNT\\Scout\\TNTSearchScoutServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TeamTNT\\Scout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "TNT Studio",
+                    "email": "info@tntstudio.hr"
+                }
+            ],
+            "description": "Driver for Laravel Scout search package based on https://github.com/teamtnt/tntsearch",
+            "keywords": [
+                "laravel",
+                "scout",
+                "search",
+                "tntsearch"
+            ],
+            "support": {
+                "issues": "https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues",
+                "source": "https://github.com/teamtnt/laravel-scout-tntsearch-driver/tree/v11.2.0"
+            },
+            "time": "2021-03-11T14:26:46+00:00"
+        },
+        {
+            "name": "teamtnt/tntsearch",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/teamtnt/tntsearch.git",
+                "reference": "c7d0f67070ea22e835bb1416b85dee0f74780fdc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/teamtnt/tntsearch/zipball/c7d0f67070ea22e835bb1416b85dee0f74780fdc",
+                "reference": "c7d0f67070ea22e835bb1416b85dee0f74780fdc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-pdo_sqlite": "*",
+                "ext-sqlite3": "*",
+                "php": "~7.1|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.*|8.*|9.*",
+                "symfony/var-dumper": "^4|^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TeamTNT\\TNTSearch\\": "src"
+                },
+                "files": [
+                    "helper/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nenad Tičarić",
+                    "email": "nticaric@gmail.com",
+                    "homepage": "http://www.tntstudio.us",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fully featured full text search engine written in PHP",
+            "homepage": "https://github.com/teamtnt/tntsearch",
+            "keywords": [
+                "Fuzzy search",
+                "bm25",
+                "fulltext",
+                "geosearch",
+                "search",
+                "stemming",
+                "teamtnt",
+                "text classification",
+                "tntsearch"
+            ],
+            "support": {
+                "issues": "https://github.com/teamtnt/tntsearch/issues",
+                "source": "https://github.com/teamtnt/tntsearch/tree/v2.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/nticaric",
+                    "type": "ko_fi"
+                },
+                {
+                    "url": "https://opencollective.com/tntsearch",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/nticaric",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-03-11T15:26:17+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -161,11 +161,13 @@ return [
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
+        Laravel\Scout\ScoutServiceProvider::class,
 
         /*
          * Package Service Providers...
          */
         Spatie\Permission\PermissionServiceProvider::class,
+        TeamTNT\Scout\TNTSearchScoutServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/backend/config/scout.php
+++ b/backend/config/scout.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'driver' => env('SCOUT_DRIVER', 'algolia'),
+    'driver' => env('SCOUT_DRIVER', 'tntsearch'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/config/scout.php
+++ b/backend/config/scout.php
@@ -1,0 +1,119 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Search Engine
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default search connection that gets used while
+    | using Laravel Scout. This connection is used when syncing all models
+    | to the search service. You should adjust this based on your needs.
+    |
+    | Supported: "algolia", "null"
+    |
+    */
+
+    'driver' => env('SCOUT_DRIVER', 'algolia'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Index Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify a prefix that will be applied to all search index
+    | names used by Scout. This prefix may be useful if you have multiple
+    | "tenants" or applications sharing the same search infrastructure.
+    |
+    */
+
+    'prefix' => env('SCOUT_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Data Syncing
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that sync your data
+    | with your search engines are queued. When this is set to "true" then
+    | all automatic data syncing will get queued for better performance.
+    |
+    */
+
+    'queue' => env('SCOUT_QUEUE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines if your data will only be synced
+    | with your search indexes after every open database transaction has
+    | been committed, thus preventing any discarded data from syncing.
+    |
+    */
+
+    'after_commit' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk Sizes
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to control the maximum chunk size when you are
+    | mass importing data into the search engine. This allows you to fine
+    | tune each of these chunk sizes based on the power of the servers.
+    |
+    */
+
+    'chunk' => [
+        'searchable' => 500,
+        'unsearchable' => 500,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to keep soft deleted records in
+    | the search indexes. Maintaining soft deleted records can be useful
+    | if your application still needs to search for the records later.
+    |
+    */
+
+    'soft_delete' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to notify the search engine
+    | of the user performing the search. This is sometimes useful if the
+    | engine supports any analytics based on this application's users.
+    |
+    | Supported engines: "algolia"
+    |
+    */
+
+    'identify' => env('SCOUT_IDENTIFY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Algolia Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Algolia settings. Algolia is a cloud hosted
+    | search engine which works great with Scout out of the box. Just plug
+    | in your application ID and admin API key to get started searching.
+    |
+    */
+
+    'algolia' => [
+        'id' => env('ALGOLIA_APP_ID', ''),
+        'secret' => env('ALGOLIA_SECRET', ''),
+    ],
+
+];

--- a/backend/config/scout.php
+++ b/backend/config/scout.php
@@ -116,4 +116,18 @@ return [
         'secret' => env('ALGOLIA_SECRET', ''),
     ],
 
+
+    'tntsearch' => [
+        'storage'  => storage_path(), //place where the index files will be stored
+        'fuzziness' => env('TNTSEARCH_FUZZINESS', false),
+        'fuzzy' => [
+            'prefix_length' => 2,
+            'max_expansions' => 50,
+            'distance' => 2
+        ],
+        'asYouType' => false,
+        'searchBoolean' => env('TNTSEARCH_BOOLEAN', false),
+        'maxDocs' => env('TNTSEARCH_MAX_DOCS', 500),
+    ],
+
 ];

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -25,7 +25,7 @@ type Query {
     permission(id: ID @eq): Permission @find
 
     "Return user accounts based on a supplied search term"
-    userSearch(search: String @search): [User!]! @paginate
+    userSearch(term: String @search): [User!]! @paginate
 }
 
 "Validate the availability of username and email via the validateNewUser query"

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -21,7 +21,11 @@ type Query {
     "Return pre-defined user roles in the application"
     role(id: ID @eq): Role @find
 
+    "Return a permission by ID"
     permission(id: ID @eq): Permission @find
+
+    "Return user accounts based on a supplied search term"
+    userSearch(search: String @search): [User!]! @paginate
 }
 
 "Validate the availability of username and email via the validateNewUser query"

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -6,8 +6,8 @@ scalar DateTime
     @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
 
 type Query {
-    "Return user accounts in the application."
-    users: [User!]! @paginate(defaultCount: 10)
+    "Return user accounts optionally based on a supplied search term"
+    userSearch(term: String @search): [User!]! @paginate(defaultCount: 10)
 
     "Return details about a specific user in the application"
     user(id: ID @eq): User @find
@@ -23,9 +23,6 @@ type Query {
 
     "Return a permission by ID"
     permission(id: ID @eq): Permission @find
-
-    "Return user accounts based on a supplied search term"
-    userSearch(term: String @search): [User!]! @paginate
 }
 
 "Validate the availability of username and email via the validateNewUser query"

--- a/backend/tests/Feature/UserQueryTest.php
+++ b/backend/tests/Feature/UserQueryTest.php
@@ -155,7 +155,7 @@ class UserQueryTest extends TestCase
 
         $response = $this->graphQL(
             'query SearchUsers ($search_term: String) {
-                userSearch (term: $search_term, first: 10) {
+                userSearch (term: $search_term) {
                     data {
                         name
                         email

--- a/backend/tests/Feature/UserQueryTest.php
+++ b/backend/tests/Feature/UserQueryTest.php
@@ -122,10 +122,25 @@ class UserQueryTest extends TestCase
         ]);
     }
 
+
     /**
+     * @return array
+     */
+    public function searchUserTermsProvider(): array
+    {
+        return [
+            ['name','abcdef'],
+            ['email','ghijkl@gmail.com'],
+            ['username','mnopqr'],
+            ['all', '']
+        ];
+    }
+
+    /**
+     * @dataProvider searchUserTermsProvider
      * @return void
      */
-    public function testThatUsersCanBeSearchedByName(): void
+    public function testThatAUserCanBeSearchedBySearchTerms(string $property_name, string $search_term): void
     {
         User::factory()->count(20)->create();
         User::factory()->create([
@@ -135,29 +150,40 @@ class UserQueryTest extends TestCase
         ]);
 
         $response = $this->graphQL(
-            'query SearchUsers {
-                userSearch (search:"abcdef", first: 10) {
+            'query SearchUsers ($search_term: String) {
+                userSearch (search: $search_term, first: 10) {
                     data {
                         name
                         email
                         username
                     }
                 }
-            }'
+            }',
+            [ 'search_term' => $search_term ]
         );
 
-        $response->assertJson([
-            'data' => [
-                'userSearch' => [
-                    'data' => [
-                        [
-                            'name' => 'abcdef',
-                            'email' => 'ghijkl@gmail.com',
-                            'username' => 'mnopqr',
-                        ]
+        if ($property_name == 'all') {
+            $response->assertJson([
+                'data' => [
+                    'userSearch' => [
+                        'data' => [ ]
+                    ]
+                ]
+            ]);
+        } else {
+            $response->assertJson([
+                'data' => [
+                    'userSearch' => [
+                        'data' => [
+                            [
+                                'name' => 'abcdef',
+                                'email' => 'ghijkl@gmail.com',
+                                'username' => 'mnopqr',
+                            ]
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        }
     }
 }

--- a/backend/tests/Feature/UserQueryTest.php
+++ b/backend/tests/Feature/UserQueryTest.php
@@ -121,4 +121,43 @@ class UserQueryTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * @return void
+     */
+    public function testThatUsersCanBeSearchedByName(): void
+    {
+        User::factory()->count(20)->create();
+        User::factory()->create([
+            'name' => 'abcdef',
+            'email' => 'ghijkl@gmail.com',
+            'username' => 'mnopqr',
+        ]);
+
+        $response = $this->graphQL(
+            'query SearchUsers {
+                userSearch (search:"abcdef", first: 10) {
+                    data {
+                        name
+                        email
+                        username
+                    }
+                }
+            }'
+        );
+
+        $response->assertJson([
+            'data' => [
+                'userSearch' => [
+                    'data' => [
+                        [
+                            'name' => 'abcdef',
+                            'email' => 'ghijkl@gmail.com',
+                            'username' => 'mnopqr',
+                        ]
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/backend/tests/Feature/UserQueryTest.php
+++ b/backend/tests/Feature/UserQueryTest.php
@@ -131,6 +131,11 @@ class UserQueryTest extends TestCase
             ['name','abcdef'],
             ['email','ghijkl@gmail.com'],
             ['username','mnopqr'],
+            ['all', 'aaaaaaaaaaaaaa'],
+            ['all', '<html>'],
+            ['all', null],
+            ['all', '12345'],
+            ['all', 12345],
             ['all', ''],
         ];
     }
@@ -139,7 +144,7 @@ class UserQueryTest extends TestCase
      * @dataProvider searchUserTermsProvider
      * @return void
      */
-    public function testThatAUserCanBeSearchedBySearchTerms(string $property_name, string $search_term): void
+    public function testThatAUserCanBeSearchedBySearchTerms(string $property_name, mixed $search_term): void
     {
         User::factory()->count(20)->create();
         User::factory()->create([
@@ -150,7 +155,7 @@ class UserQueryTest extends TestCase
 
         $response = $this->graphQL(
             'query SearchUsers ($search_term: String) {
-                userSearch (search: $search_term, first: 10) {
+                userSearch (term: $search_term, first: 10) {
                     data {
                         name
                         email
@@ -158,7 +163,7 @@ class UserQueryTest extends TestCase
                     }
                 }
             }',
-            [ 'search_term' => $search_term ]
+            [ 'search_term' => (string)$search_term ]
         );
 
         if ($property_name == 'all') {

--- a/backend/tests/Feature/UserQueryTest.php
+++ b/backend/tests/Feature/UserQueryTest.php
@@ -122,7 +122,6 @@ class UserQueryTest extends TestCase
         ]);
     }
 
-
     /**
      * @return array
      */
@@ -132,7 +131,7 @@ class UserQueryTest extends TestCase
             ['name','abcdef'],
             ['email','ghijkl@gmail.com'],
             ['username','mnopqr'],
-            ['all', '']
+            ['all', ''],
         ];
     }
 
@@ -166,9 +165,9 @@ class UserQueryTest extends TestCase
             $response->assertJson([
                 'data' => [
                     'userSearch' => [
-                        'data' => [ ]
-                    ]
-                ]
+                        'data' => [ ],
+                    ],
+                ],
             ]);
         } else {
             $response->assertJson([
@@ -179,7 +178,7 @@ class UserQueryTest extends TestCase
                                 'name' => 'abcdef',
                                 'email' => 'ghijkl@gmail.com',
                                 'username' => 'mnopqr',
-                            ]
+                            ],
                         ],
                     ],
                 ],

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -16,7 +16,7 @@ export const CURRENT_USER = gql`
 `;
 export const GET_USERS = gql`
   query users($page:Int) {
-    users(page:$page) {
+    userSearch(page:$page) {
       paginatorInfo {
         count
         currentPage

--- a/client/src/pages/Admin/UsersIndex.jest.spec.js
+++ b/client/src/pages/Admin/UsersIndex.jest.spec.js
@@ -31,9 +31,9 @@ describe('User Index page mount', () => {
   });
   test ('users are populated on the page', async () => {
     await wrapper.setData({
-      users: { 
+      userSearch: {
         data: [
-          {name:'test1', email:'test1@msu.edu'}, 
+          {name:'test1', email:'test1@msu.edu'},
           {name:'test2', email:'test2@msu.edu'}
         ],
         paginatorInfo: { lastPage:10 }

--- a/client/src/pages/Admin/UsersIndex.vue
+++ b/client/src/pages/Admin/UsersIndex.vue
@@ -3,9 +3,9 @@
     <h2 class="q-pl-lg">
       All Users
     </h2>
-    <q-banner v-if="users.data">
+    <q-banner v-if="userSearch.data">
       <q-item
-        v-for="user in users.data"
+        v-for="user in userSearch.data"
         :key="user.id"
         data-cy="userListItem"
       >
@@ -38,7 +38,7 @@
       <q-pagination
         v-model="current_page"
         class="q-pa-lg flex flex-center"
-        :max="users.paginatorInfo.lastPage"
+        :max="userSearch.paginatorInfo.lastPage"
       />
     </q-banner>
   </div>
@@ -54,14 +54,14 @@ export default {
   },
   data() {
     return {
-      users: {
+      userSearch: {
         data: null
       },
       current_page: 1
     }
   },
   apollo: {
-    users: {
+    userSearch: {
       query: GET_USERS,
       variables () {
         return {


### PR DESCRIPTION
This extends the GraphQL API to search for users by various search terms.

Closes #175 

Example GraphQL Playground query:

```graphql
query SearchUsers {
  userSearch(term:"abcdef", first: 10, page: 1) {
    data {
      id	
      name
      email
      username
    }
  }
}
```

Edit: changed the name of the function argument from 'search' to 'term'