### PR TITLE
feat: Add Submissions

### DIFF
--- a/backend/app/Models/Publication.php
+++ b/backend/app/Models/Publication.php
@@ -26,6 +26,8 @@ class Publication extends Model
 
     /**
      * Submissioss that belong to a publication
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function submissions()
     {

--- a/backend/app/Models/Publication.php
+++ b/backend/app/Models/Publication.php
@@ -25,7 +25,7 @@ class Publication extends Model
     }
 
     /**
-     *
+     * Submissioss that belong to a publication
      */
     public function submissions()
     {

--- a/backend/app/Models/Publication.php
+++ b/backend/app/Models/Publication.php
@@ -23,4 +23,12 @@ class Publication extends Model
     {
         return $this->belongsToMany(User::class, 'publication_users');
     }
+
+    /**
+     *
+     */
+    public function submissions()
+    {
+        return $this->hasMany(Submission::class);
+    }
 }

--- a/backend/app/Models/Publication.php
+++ b/backend/app/Models/Publication.php
@@ -25,7 +25,7 @@ class Publication extends Model
     }
 
     /**
-     * Submissioss that belong to a publication
+     * Submissions that belong to a publication
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -10,9 +10,14 @@ class Role extends ParentModel
 {
     use HasFactory;
 
+    // Relative to the application
     public const APPLICATION_ADMINISTRATOR = 'Application Administrator';
+
+    // Relative to publications
     public const PUBLICATION_ADMINISTRATOR = 'Publication Administrator';
     public const EDITOR = 'Editor';
+
+    // Relative to submissions
     public const REVIEW_COORDINATOR = 'Review Coordinator';
     public const REVIEWER = 'Reviewer';
     public const SUBMITTER = 'Submitter';

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -17,6 +17,9 @@ class Submission extends Model
         'publication_id',
     ];
 
+    /**
+     * The publication that the submission belongs to
+     */
     public function publication()
     {
         return $this->belongsTo(Publication::class, 'publication_id');

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Models;
+
+use App\Models\Publication;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,5 +14,12 @@ class Submission extends Model
 
     protected $fillable = [
         'title',
+        'publication_id',
     ];
+
+    public function publication()
+    {
+        return $this->belongsTo(Publication::class, 'publication_id');
+    }
+
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -9,7 +9,11 @@ use Illuminate\Database\Eloquent\Model;
 class Submission extends Model
 {
     use HasFactory;
-
+    /**     
+     * The attributes that are mass assignable.     
+     *     
+     * @var array    
+     */
     protected $fillable = [
         'title',
         'publication_id',

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use App\Models\Publication;
-
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -25,4 +23,11 @@ class Submission extends Model
         return $this->belongsTo(Publication::class, 'publication_id');
     }
 
+    /**
+     * Users that belong to the submission
+     */
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -9,10 +9,11 @@ use Illuminate\Database\Eloquent\Model;
 class Submission extends Model
 {
     use HasFactory;
-    /**     
-     * The attributes that are mass assignable.     
-     *     
-     * @var array    
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
      */
     protected $fillable = [
         'title',

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -28,6 +28,8 @@ class Submission extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class)
+            ->withTimestamps()
+            ->withPivot('role_id');
     }
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -17,6 +17,8 @@ class Submission extends Model
 
     /**
      * The publication that the submission belongs to
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function publication()
     {
@@ -25,6 +27,8 @@ class Submission extends Model
 
     /**
      * Users that belong to the submission
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function users()
     {

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Submission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+    ];
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -153,6 +153,8 @@ class User extends Authenticatable implements MustVerifyEmail
 
     /**
      * Submissions that belong to the user
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function submissions()
     {

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -150,4 +150,12 @@ class User extends Authenticatable implements MustVerifyEmail
 
         return $array;
     }
+
+    /**
+     * Submissions that belong to the user
+     */
+    public function submissions()
+    {
+        return $this->belongsToMany(Submission::class);
+    }
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -156,6 +156,8 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function submissions()
     {
-        return $this->belongsToMany(Submission::class);
+        return $this->belongsToMany(Submission::class)
+            ->withTimestamps()
+            ->withPivot('role_id');
     }
 }

--- a/backend/database/factories/SubmissionFactory.php
+++ b/backend/database/factories/SubmissionFactory.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Submission;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SubmissionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Submission::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(10),
+        ];
+    }
+}

--- a/backend/database/factories/SubmissionFactory.php
+++ b/backend/database/factories/SubmissionFactory.php
@@ -23,17 +23,9 @@ class SubmissionFactory extends Factory
      */
     public function definition()
     {
-        $publication_id = 1;
-
-        // If there are existing publications, assign the submission to a random one
-        $publication_ids = Publication::pluck('id')->toArray();
-        if (count($publication_ids) > 0) {
-            $publication_id = $this->faker->randomElement($publication_ids);
-        }
-
         return [
             'title' => $this->faker->sentence(10, true),
-            'publication_id' => $publication_id,
+            'publication_id' => Publication::factory(),
         ];
     }
 }

--- a/backend/database/factories/SubmissionFactory.php
+++ b/backend/database/factories/SubmissionFactory.php
@@ -23,9 +23,17 @@ class SubmissionFactory extends Factory
      */
     public function definition()
     {
+        $publication_id = 1;
+
+        // If there are existing publications, assign the submission to a random one
+        $publication_ids = Publication::pluck('id')->toArray();
+        if (count($publication_ids) > 0) {
+            $publication_id = $this->faker->randomElement($publication_ids);
+        }
+
         return [
             'title' => $this->faker->sentence(10, true),
-            'publication_id' => Publication::first()->id,
+            'publication_id' => $publication_id,
         ];
     }
 }

--- a/backend/database/factories/SubmissionFactory.php
+++ b/backend/database/factories/SubmissionFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\Publication;
 use App\Models\Submission;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -23,7 +24,8 @@ class SubmissionFactory extends Factory
     public function definition()
     {
         return [
-            'title' => $this->faker->sentence(10),
+            'title' => $this->faker->sentence(10, true),
+            'publication_id' => Publication::first()->id,
         ];
     }
 }

--- a/backend/database/migrations/2021_06_01_195428_create_submissions_table.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSubmissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('submissions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('title')->nullable(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('submissions');
+    }
+}

--- a/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
@@ -54,6 +54,5 @@ class CreateSubmissionsTables extends Migration
     {
         Schema::dropIfExists('submissions');
         Schema::dropIfExists('submissions_users');
-        Schema::dropIfExists('publications_submissions');
     }
 }

--- a/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSubmissionsTable extends Migration
+class CreateSubmissionsTables extends Migration
 {
     /**
      * Run the migrations.

--- a/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
@@ -17,6 +17,11 @@ class CreateSubmissionsTables extends Migration
             $table->id();
             $table->timestamps();
             $table->string('title')->nullable(false);
+            $table->unsignedBigInteger('publication_id');
+
+            $table->foreign('publication_id')
+                ->references('id')
+                ->on('publications');
         });
     }
 
@@ -28,5 +33,6 @@ class CreateSubmissionsTables extends Migration
     public function down()
     {
         Schema::dropIfExists('submissions');
+        Schema::dropIfExists('publications_submissions');
     }
 }

--- a/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
@@ -23,6 +23,26 @@ class CreateSubmissionsTables extends Migration
                 ->references('id')
                 ->on('publications');
         });
+
+        Schema::create('submission_user', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('submission_id');
+            $table->unsignedBigInteger('role_id');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users');
+
+            $table->foreign('submission_id')
+                ->references('id')
+                ->on('submissions');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles');
+        });
     }
 
     /**
@@ -33,6 +53,7 @@ class CreateSubmissionsTables extends Migration
     public function down()
     {
         Schema::dropIfExists('submissions');
+        Schema::dropIfExists('submissions_users');
         Schema::dropIfExists('publications_submissions');
     }
 }

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -31,5 +31,11 @@ class DatabaseSeeder extends Seeder
             'password' => Hash::make('adminPassword!@#'),
         ]);
         $user->assignRole(Role::APPLICATION_ADMINISTRATOR);
+
+        $publication_seeder = new PublicationSeeder();
+        $publication_seeder->run();
+
+        $submission_seeder = new SubmissionSeeder();
+        $submission_seeder->run();
     }
 }

--- a/backend/database/seeders/PublicationSeeder.php
+++ b/backend/database/seeders/PublicationSeeder.php
@@ -15,7 +15,7 @@ class PublicationSeeder extends Seeder
      */
     public function run()
     {
-        $publication = Publication::factory()->create([
+        Publication::factory()->create([
             'id' => 1,
             'name' => 'Collaborative Review Organization',
         ]);

--- a/backend/database/seeders/PublicationSeeder.php
+++ b/backend/database/seeders/PublicationSeeder.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use App\Models\Publication;
-use App\Models\Submission;
 use Illuminate\Database\Seeder;
 
-class SubmissionSeeder extends Seeder
+class PublicationSeeder extends Seeder
 {
     /**
      * Run the database seeds.
@@ -16,9 +15,9 @@ class SubmissionSeeder extends Seeder
      */
     public function run()
     {
-        $submission = Submission::factory()->create([
-            'title' => 'CCR Test Submission 1',
-            'publication_id' => Publication::first()->id,
+        $publication = Publication::factory()->create([
+            'id' => 1,
+            'name' => 'Collaborative Review Organization',
         ]);
     }
 }

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Submission;
+
+class SubmissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $submission = Submission::factory()->create([
+            'title' => 'Collaborative Review Organization',
+        ]);
+    }
+}

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-use App\Models\Publication;
 use App\Models\Submission;
 use Illuminate\Database\Seeder;
 
@@ -18,7 +17,7 @@ class SubmissionSeeder extends Seeder
     {
         $submission = Submission::factory()->create([
             'title' => 'CCR Test Submission 1',
-            'publication_id' => Publication::first()->id,
+            'publication_id' => 1,
         ]);
     }
 }

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -15,7 +15,7 @@ class SubmissionSeeder extends Seeder
      */
     public function run()
     {
-        $submission = Submission::factory()->create([
+        Submission::factory()->create([
             'title' => 'CCR Test Submission 1',
             'publication_id' => 1,
         ]);

--- a/backend/graphql/publication.graphql
+++ b/backend/graphql/publication.graphql
@@ -6,4 +6,5 @@ type Publication {
     name: String!
     created_at: DateTime
     updated_at: DateTime
+    submissions: [Submission]! @belongsToMany
 }

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -1,11 +1,11 @@
+#import academic_profiles.graphql
 #import permission.graphql
-#import role.graphql
-#import user.graphql
-#import social_media.graphql
 #import profile_metadata.graphql
 #import publication.graphql
-#import academic_profiles.graphql
+#import social_media.graphql
 #import submission.graphql
+#import role.graphql
+#import user.graphql
 
 type Query {
     "Return information about the currently logged in user"

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -1,3 +1,12 @@
+#import permission.graphql
+#import role.graphql
+#import user.graphql
+#import social_media.graphql
+#import profile_metadata.graphql
+#import publication.graphql
+#import academic_profiles.graphql
+#import submission.graphql
+
 type Query {
     "Return information about the currently logged in user"
     currentUser: User @auth
@@ -22,6 +31,12 @@ type Query {
 
     "Return all publications"
     publications: [Publication!]! @paginate(defaultCount: 100)
+
+    "Return a submission by ID"
+    submission(id: ID @eq): Submission @find
+
+    "Return all submissions"
+    submissions: [Submission!]! @paginate(defaultCount: 100)
 }
 
 type Mutation {
@@ -72,14 +87,6 @@ scalar Date @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date")
 "A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
 scalar DateTime
     @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
-
-#import permission.graphql
-#import role.graphql
-#import user.graphql
-#import social_media.graphql
-#import profile_metadata.graphql
-#import publication.graphql
-#import academic_profiles.graphql
 
 """
 Input type for creating a new user via the userCreate mutation

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -1,0 +1,11 @@
+"""
+A Submission
+"""
+type Submission {
+    id: ID!
+    title: String
+    created_at: DateTime!
+    updated_at: DateTime
+    publication: publication
+    users: [User!]! @belongsToMany
+}

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -6,6 +6,6 @@ type Submission {
     title: String
     created_at: DateTime!
     updated_at: DateTime
-    publication: publication
+    publication: Publication
     users: [User!]! @belongsToMany
 }

--- a/backend/graphql/user.graphql
+++ b/backend/graphql/user.graphql
@@ -12,4 +12,5 @@ type User {
     roles: [Role!]! @belongsToMany
     permissions: [Permission!] @belongsToMany
     profile_metadata: ProfileMetadata
+    submissions: [Submission]! @belongsToMany
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -45,12 +45,14 @@ class SubmissionTest extends TestCase
 
         // Create submissions and attach them to users randomly with random roles
         for ($i = 0; $i < $submission_count; $i++) {
-            $random_role_id = Role::whereIn('name',
+            $random_role_id = Role::whereIn(
+                'name',
                 [
                     Role::REVIEW_COORDINATOR,
                     Role::REVIEWER,
                     Role::SUBMITTER,
-                ])
+                ]
+            )
                 ->get()
                 ->pluck('id')
                 ->random();
@@ -73,12 +75,12 @@ class SubmissionTest extends TestCase
                 );
             }
         }
-        Submission::all()->map(function($submission) use ($user_count) {
+        Submission::all()->map(function ($submission) use ($user_count) {
             $this->assertNotEmpty($submission->users);
             $this->assertGreaterThan(0, $submission->users->count());
             $this->assertLessThanOrEqual($user_count, $submission->users->count());
         });
-        User::all()->map(function($user) use ($submission_count) {
+        User::all()->map(function ($user) use ($submission_count) {
             $this->assertLessThanOrEqual($submission_count, $user->submissions->count());
         });
     }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Publication;
+use App\Models\Submission;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SubmissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return void
+     */
+    public function testThatSubmissionsHaveAOneToManyRelationshipWithPublications()
+    {
+        $publication = Publication::factory()->create([
+            'name' => 'Test Publication #1',
+        ]);
+        $submissions = Submission::factory()->count(20)->create();
+        $this->assertEquals($submissions->first()->publication->id, 1);
+        $this->assertEquals($submissions->last()->publication->id, 1);
+        $this->assertEquals($publication->submissions->count(), 20);
+    }
+}

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -20,9 +20,14 @@ class SubmissionTest extends TestCase
         $publication = Publication::factory()->create([
             'name' => 'Test Publication #1',
         ]);
-        $submissions = Submission::factory()->count(20)->create();
-        $this->assertEquals($submissions->first()->publication->id, 1);
-        $this->assertEquals($submissions->last()->publication->id, 1);
-        $this->assertEquals($publication->submissions->count(), 20);
+        Publication::factory()->count(6)->create();
+        Submission::factory()->count(10)->for($publication)->create();
+        Submission::factory()->count(16)->create();
+        $this->assertEquals(1, Submission::where('publication_id', $publication->id)
+            ->pluck('publication_id')->unique()->count()
+        );
+        $this->assertGreaterThanOrEqual(10, $publication->submissions->count());
+        $this->assertLessThanOrEqual(26, $publication->submissions->count());
+    }
     }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\Publication;
+use App\Models\Role;
 use App\Models\Submission;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -24,10 +26,34 @@ class SubmissionTest extends TestCase
         Submission::factory()->count(10)->for($publication)->create();
         Submission::factory()->count(16)->create();
         $this->assertEquals(1, Submission::where('publication_id', $publication->id)
-            ->pluck('publication_id')->unique()->count()
-        );
+            ->pluck('publication_id')->unique()->count());
         $this->assertGreaterThanOrEqual(10, $publication->submissions->count());
         $this->assertLessThanOrEqual(26, $publication->submissions->count());
     }
+
+    /**
+     * @return void
+     * @doesNotPerformAssertions
+     */
+    public function testThatSubmissionsHaveAManyToManyRelationshipWithUsers()
+    {
+        $publication = Publication::factory()->create([
+            'name' => 'Test Publication #2',
+        ]);
+        $users = User::factory()->count(6)->create();
+        $submissions = Submission::factory()
+            ->count(4)
+            ->hasAttached(
+                $users,
+                [
+                    'role_id' => Role::whereIn('name', [
+                        Role::REVIEW_COORDINATOR,
+                        Role::REVIEWER,
+                        Role::SUBMITTER,
+                    ])->get()->pluck('id')->random(),
+                ]
+            )
+            ->create();
+        print_r($submissions->toArray());
     }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -81,7 +81,8 @@ class SubmissionTest extends TestCase
             $this->assertLessThanOrEqual(2, $submission->users->count());
             $submission->users->map(function ($user) {
                 $this->assertIsInt(
-                    User::where('id',
+                    User::where(
+                        'id',
                         $user->id
                     )->firstOrFail()->id
                 );
@@ -91,7 +92,8 @@ class SubmissionTest extends TestCase
             $this->assertLessThanOrEqual($submission_count, $user->submissions->count());
             $user->submissions->map(function ($submission) {
                 $this->assertIsInt(
-                    Submission::where('id',
+                    Submission::where(
+                        'id',
                         $submission->id
                     )->firstOrFail()->id
                 );

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -8,16 +8,18 @@ use App\Models\Role;
 use App\Models\Submission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 
 class SubmissionTest extends TestCase
 {
+    use MakesGraphQLRequests;
     use RefreshDatabase;
 
     /**
      * @return void
      */
-    public function testThatSubmissionsHaveAOneToManyRelationshipWithPublications()
+    public function testSubmissionsHaveAOneToManyRelationshipWithPublications()
     {
         $publication = Publication::factory()->create([
             'name' => 'Test Publication #1',
@@ -33,7 +35,7 @@ class SubmissionTest extends TestCase
     /**
      * @return void
      */
-    public function testThatSubmissionsHaveAManyToManyRelationshipWithUsers()
+    public function testSubmissionsHaveAManyToManyRelationshipWithUsers()
     {
         $submission_count = 4;
         $user_count = 6;
@@ -62,8 +64,8 @@ class SubmissionTest extends TestCase
                     'role_id' => $random_role_id,
                 ]
             )
-            ->for($publication)
-            ->create();
+                ->for($publication)
+                ->create();
 
             // Ensure at least one Submitter is attached if one was not previously attached
             if ($random_role_id !== $submitter_id) {
@@ -82,5 +84,165 @@ class SubmissionTest extends TestCase
         User::all()->map(function ($user) use ($submission_count) {
             $this->assertLessThanOrEqual($submission_count, $user->submissions->count());
         });
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndividualSubmissionsCanBeQueriedById()
+    {
+        $submission = Submission::factory()->create([
+            'title' => 'Test Submission for Querying an Individual Submission',
+        ]);
+        $response = $this->graphQL(
+            'query GetSubmission($id: ID!) {
+                submission (id: $id) {
+                    id
+                    title
+                }
+            }',
+            [ 'id' => $submission->id ]
+        );
+        $expected_data = [
+            'submission' => [
+                'id' => (string)$submission->id,
+                'title' => 'Test Submission for Querying an Individual Submission',
+            ],
+        ];
+        $response->assertJsonPath('data', $expected_data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAllSubmissionsCanBeQueried()
+    {
+        $submission_1 = Submission::factory()->create([
+            'title' => 'Test Submission #1 for Querying All Submissions',
+        ]);
+        $submission_2 = Submission::factory()->create([
+            'title' => 'Test Submission #2 for Querying All Submissions',
+        ]);
+        $response = $this->graphQL(
+            'query GetSubmissions {
+                submissions {
+                    data {
+                        id
+                        title
+                    }
+                }
+            }'
+        );
+        $expected_data = [
+            'submissions' => [
+                'data' => [
+                    [
+                        'id' => (string)$submission_1->id,
+                        'title' => 'Test Submission #1 for Querying All Submissions',
+                    ],
+                    [
+                        'id' => (string)$submission_2->id,
+                        'title' => 'Test Submission #2 for Querying All Submissions',
+                    ],
+                ],
+            ],
+        ];
+        $response->assertJsonPath('data', $expected_data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSubmissionsCanBeQueriedForAPublication()
+    {
+        $publication = Publication::factory()->create([
+            'name' => 'Test Publication #3',
+        ]);
+        $submission = Submission::factory()->hasAttached(
+            User::factory()->create(),
+            [
+                'role_id' => Role::where('name', Role::SUBMITTER)->first()->id,
+            ]
+        )
+            ->for($publication)
+            ->create([
+                'title' => 'Submission for Publication #3',
+            ]);
+        $response = $this->graphQL(
+            'query GetSubmissionsByPublication($id: ID!) {
+                publication (id: $id) {
+                    id
+                    name
+                    submissions {
+                        id
+                        title
+                    }
+                }
+            }',
+            [ 'id' => $publication->id ]
+        );
+        $expected_data = [
+            'publication' => [
+                'id' => (string)$publication->id,
+                'name' => 'Test Publication #3',
+                'submissions' => [
+                    [
+                        'id' => (string)$submission->id,
+                        'title' => 'Submission for Publication #3',
+                    ],
+                ],
+            ],
+        ];
+        $response->assertJsonPath('data', $expected_data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAllSubmissionsCanBeQueriedForAUser()
+    {
+        $publication = Publication::factory()->create([
+            'name' => 'Test Publication #4',
+        ]);
+        $user = User::factory()->create([
+            'name' => 'Test User With Submission #1',
+        ]);
+        $submission = Submission::factory()->hasAttached(
+            $user,
+            [
+                'role_id' => Role::where('name', Role::SUBMITTER)->first()->id,
+            ]
+        )
+            ->for($publication)
+            ->create([
+                'title' => 'Test Submission for Test User With Submission #1',
+            ]);
+
+        $response = $this->graphQL(
+            'query GetSubmissionsByUser($id: ID!) {
+                user (id: $id) {
+                    id
+                    name
+                    submissions {
+                        id
+                        title
+                    }
+                }
+            }',
+            [ 'id' => $user->id ]
+        );
+        $expected_data = [
+            'user' => [
+                'id' => (string)$user->id,
+                'name' => 'Test User With Submission #1',
+                'submissions' => [
+                    [
+                        'id' => (string)$submission->id,
+                        'title' => 'Test Submission for Test User With Submission #1',
+                    ],
+                ],
+            ],
+        ];
+        $response->assertJsonPath('data', $expected_data);
     }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -79,9 +79,23 @@ class SubmissionTest extends TestCase
         Submission::all()->map(function ($submission) {
             $this->assertGreaterThan(0, $submission->users->count());
             $this->assertLessThanOrEqual(2, $submission->users->count());
+            $submission->users->map(function ($user) {
+                $this->assertIsInt(
+                    User::where('id',
+                        $user->id
+                    )->firstOrFail()->id
+                );
+            });
         });
         User::all()->map(function ($user) use ($submission_count) {
             $this->assertLessThanOrEqual($submission_count, $user->submissions->count());
+            $user->submissions->map(function ($submission) {
+                $this->assertIsInt(
+                    Submission::where('id',
+                        $submission->id
+                    )->firstOrFail()->id
+                );
+            });
         });
     }
 

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -76,7 +76,6 @@ class SubmissionTest extends TestCase
             }
         }
         Submission::all()->map(function ($submission) use ($user_count) {
-            $this->assertNotEmpty($submission->users);
             $this->assertGreaterThan(0, $submission->users->count());
             $this->assertLessThanOrEqual($user_count, $submission->users->count());
         });

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -28,8 +28,7 @@ class SubmissionTest extends TestCase
         $submissions = Submission::factory()->count(10)->for($publication)->create();
         Submission::factory()->count(16)->create();
         $this->assertEquals(1, $submissions->pluck('publication_id')->unique()->count());
-        $this->assertGreaterThanOrEqual(10, $publication->submissions->count());
-        $this->assertLessThanOrEqual(26, $publication->submissions->count());
+        $this->assertEquals(10, $publication->submissions->count());
     }
 
     /**
@@ -77,9 +76,9 @@ class SubmissionTest extends TestCase
                 );
             }
         }
-        Submission::all()->map(function ($submission) use ($user_count) {
+        Submission::all()->map(function ($submission) {
             $this->assertGreaterThan(0, $submission->users->count());
-            $this->assertLessThanOrEqual($user_count, $submission->users->count());
+            $this->assertLessThanOrEqual(2, $submission->users->count());
         });
         User::all()->map(function ($user) use ($submission_count) {
             $this->assertLessThanOrEqual($submission_count, $user->submissions->count());

--- a/client/test/cypress/integration/admin/publications.spec.js
+++ b/client/test/cypress/integration/admin/publications.spec.js
@@ -24,7 +24,7 @@ describe('Publications', () => {
   it('prevents publication creation when the name is empty', () => {
     cy.dataCy('new_publication_input')
       .type('{enter}');
-    cy.dataCy('no_publications_message').should('be.visible');
+    cy.dataCy('publications_list');
     cy.dataCy('create_publication_notify').should('be.visible').should('have.class','bg-negative');
     cy.injectAxe();
     cy.dataCy('new_publication_input')


### PR DESCRIPTION
This PR:

* Introduces the `Submission` model
* Establishes a one-to-many relationship between submissions and publications
* Establishes a many-to-many relationship between submissions and users
* Updates the GraphQL endpoint for submissions
    * submission - get a submission by ID
    * submissions - get all submissions
    * user.submissions - get all submissions for a user
    * publication.submissions - get all submissions for a publication
* Adds seeding for publications and submissions