### PR TITLE
test(client): disable animations during tests

### DIFF
--- a/.lando.extras.yml
+++ b/.lando.extras.yml
@@ -21,7 +21,7 @@ cypress:
         overrides:
           image: "cypress/included:6.3.0"
           environment:
-            - DISPLAY
+            ELECTRON_EXTRA_LAUNCH_ARGS: "--force-prefers-reduced-motion"
     tooling:
       cypress:
         service: cypress

--- a/client/src/css/app.sass
+++ b/client/src/css/app.sass
@@ -48,3 +48,7 @@ fieldset
 
 .q-tab--active .q-tab__label
     font-weight: 500
+
+@media(prefers-reduced-motion)
+    *
+        transition: none !important

--- a/client/test/cypress/plugins/index.js
+++ b/client/test/cypress/plugins/index.js
@@ -36,4 +36,15 @@ module.exports = (on, config) => {
       });
     }
   });
+
+  on('before:browser:launch' , (browser = {}, launchOptions) => {
+    const REDUCE = 1;
+    if (browser.family === 'firefox') {
+      launchOptions.preferences['ui.prefersReducedMotion'] = REDUCE;
+    }
+    if (browser.family === 'chromium') {
+      launchOptions.args.push('--force-prefers-reduced-motion');
+    }
+    return launchOptions;
+  })
 };


### PR DESCRIPTION
This PR disables animations during cypress tests using the prefers-reduced-motion media query.  As a side effect this also causes the application to respect prefers-reduced-motion in general.