### PR TITLE
feat: Test that current user is the default submitter

### DIFF
--- a/client/src/pages/Submissions.vue
+++ b/client/src/pages/Submissions.vue
@@ -71,6 +71,7 @@
             class="column"
           >
             <router-link
+              data-cy="submission_link"
               :to="{
                 name: 'submission_details',
                 params: { id: submission.id },

--- a/client/test/cypress/integration/submissions.spec.js
+++ b/client/test/cypress/integration/submissions.spec.js
@@ -1,50 +1,48 @@
 /// <reference types="Cypress" />
 /// <reference path="../support/index.d.ts" />
 
-import 'cypress-axe';
-import 'cypress-file-upload';
+import "cypress-axe"
+import "cypress-file-upload"
 
-describe('Submissions', () => {
-  it('creates new submissions', () => {
-    cy.task('resetDb');
-    cy.login({ email: "applicationadministrator@ccrproject.dev" });
-    cy.visit('submissions');
-    cy.injectAxe();
-    cy.dataCy('new_submission_title_input')
-      .type('Submission from Cypress{enter}');
-    cy.dataCy('new_submission_publication_input')
-      .click();
-    cy.get('.publication_options')
-      .contains('CCR Test Publication 1')
-      .click();
-    cy.dataCy('new_submission_file_upload_input')
-      .attachFile('test.txt');
-    cy.dataCy('save_submission')
-      .click();
-    cy.dataCy('submissions_list')
-      .contains('Submission from Cypress');
-    cy.dataCy('create_submission_notify').should('be.visible').should('have.class','bg-positive');
-    cy.get('.q-notification--top-enter-active').should('not.exist');
+describe("Submissions", () => {
+  it("creates new submissions", () => {
+    cy.task("resetDb")
+    cy.login({ email: "applicationadministrator@ccrproject.dev" })
+    cy.visit("submissions")
+    cy.injectAxe()
+    cy.dataCy("new_submission_title_input").type(
+      "Submission from Cypress{enter}"
+    )
+    cy.dataCy("new_submission_publication_input").click()
+    cy.get(".publication_options").contains("CCR Test Publication 1").click()
+    cy.dataCy("new_submission_file_upload_input").attachFile("test.txt")
+    cy.dataCy("save_submission").click()
+    cy.dataCy("submissions_list").contains("Submission from Cypress")
+    cy.dataCy("create_submission_notify")
+      .should("be.visible")
+      .should("have.class", "bg-positive")
+    cy.get(".q-notification--top-enter-active").should("not.exist")
     cy.checkA11y(null, {
       rules: {
-          'nested-interactive': { enabled: false },
+        "nested-interactive": { enabled: false },
       },
-    });
-  });
+    })
+  })
 
-  it('prevents submission creation when the title exceeds the maximum length', () => {
-    const name_513_characters = '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123';
-    cy.task('resetDb');
-    cy.login({ email: "applicationadministrator@ccrproject.dev" });
-    cy.visit('submissions');
-    cy.injectAxe();
-    cy.dataCy('new_submission_title_input')
-      .type(name_513_characters + '{enter}');
-    cy.dataCy('create_submission_notify').should('be.visible').should('have.class','bg-negative');
-    cy.get('.q-notification--top-enter-active').should('not.exist');
-    cy.checkA11y();
-  });
-
-});
-
-
+  it("prevents submission creation when the title exceeds the maximum length", () => {
+    const name_513_characters =
+      "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123"
+    cy.task("resetDb")
+    cy.login({ email: "applicationadministrator@ccrproject.dev" })
+    cy.visit("submissions")
+    cy.injectAxe()
+    cy.dataCy("new_submission_title_input").type(
+      name_513_characters + "{enter}"
+    )
+    cy.dataCy("create_submission_notify")
+      .should("be.visible")
+      .should("have.class", "bg-negative")
+    cy.get(".q-notification--top-enter-active").should("not.exist")
+    cy.checkA11y()
+  })
+})

--- a/client/test/cypress/integration/submissions.spec.js
+++ b/client/test/cypress/integration/submissions.spec.js
@@ -22,6 +22,10 @@ describe("Submissions", () => {
       .should("be.visible")
       .should("have.class", "bg-positive")
     cy.get(".q-notification--top-enter-active").should("not.exist")
+    cy.dataCy("submission_link").contains("Submission from Cypress").click()
+    cy.dataCy("list_assigned_submitters").contains(
+      "applicationadministrator@ccrproject.dev"
+    )
     cy.checkA11y(null, {
       rules: {
         "nested-interactive": { enabled: false },


### PR DESCRIPTION
This PR 

* Makes the Submissions Cypress spec conform to ESLint standards
* Adds an assertion to the Submissions Cypress spec to ensure that the currently logged in user is assigned as the submitter by default upon creating a new submission.
    - The work to make this default assignment was completed inadvertently in issue #491.

Closes Issue #501 