### PR TITLE
feat: Prepare Backend for Database Notifications

### DIFF
--- a/backend/app/Notifications/SubmissionCreation.php
+++ b/backend/app/Notifications/SubmissionCreation.php
@@ -59,6 +59,9 @@ class SubmissionCreation extends Notification implements ShouldQueue
     public function toArray()
     {
         return [
+            'body' => $this->creationData['body'],
+            'action' => $this->creationData['action'],
+            'url' => $this->creationData['url'],
             'submission_id' => $this->creationData['submission_id'],
         ];
     }

--- a/backend/app/Notifications/SubmissionCreation.php
+++ b/backend/app/Notifications/SubmissionCreation.php
@@ -20,6 +20,7 @@ class SubmissionCreation extends Notification implements ShouldQueue
     /**
      * Create a new notification instance.
      *
+     * @param array $creationData
      * @return void
      */
     public function __construct($creationData)

--- a/backend/app/Notifications/SubmissionCreation.php
+++ b/backend/app/Notifications/SubmissionCreation.php
@@ -12,6 +12,9 @@ class SubmissionCreation extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    /**
+     * @var array
+     */
     private $creationData;
 
     /**
@@ -28,10 +31,9 @@ class SubmissionCreation extends Notification implements ShouldQueue
     /**
      * Get the notification's delivery channels.
      *
-     * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via()
     {
         return ['database'];
     }
@@ -39,10 +41,9 @@ class SubmissionCreation extends Notification implements ShouldQueue
     /**
      * Get the mail representation of the notification.
      *
-     * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
-    public function toMail($notifiable)
+    public function toMail()
     {
         return (new MailMessage())
                     ->line($this->creationData['body'])
@@ -52,23 +53,9 @@ class SubmissionCreation extends Notification implements ShouldQueue
     /**
      * Get the array representation of the notification for the client.
      *
-     * @param  mixed  $notifiable
      * @return array
      */
-    public function toArray($notifiable)
-    {
-        return [
-            'submission_id' => $this->creationData['submission_id'],
-        ];
-    }
-
-    /**
-     * Get the array representation of the notification for the datatabase.
-     *
-     * @param  mixed  $notifiable
-     * @return array
-     */
-    public function toDatabase($notifiable)
+    public function toArray()
     {
         return [
             'submission_id' => $this->creationData['submission_id'],

--- a/backend/app/Notifications/SubmissionCreation.php
+++ b/backend/app/Notifications/SubmissionCreation.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 class SubmissionCreation extends Notification implements ShouldQueue
 {
     use Queueable;
-
-    public $afterCommit = true;
 
     private $creationData;
 
@@ -23,6 +21,7 @@ class SubmissionCreation extends Notification implements ShouldQueue
      */
     public function __construct($creationData)
     {
+        $this->after_commit = true;
         $this->creationData = $creationData;
     }
 
@@ -34,7 +33,7 @@ class SubmissionCreation extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['database'];
     }
 
     /**
@@ -51,7 +50,7 @@ class SubmissionCreation extends Notification implements ShouldQueue
     }
 
     /**
-     * Get the array representation of the notification.
+     * Get the array representation of the notification for the client.
      *
      * @param  mixed  $notifiable
      * @return array
@@ -59,7 +58,20 @@ class SubmissionCreation extends Notification implements ShouldQueue
     public function toArray($notifiable)
     {
         return [
-            'submission_id' => $this->creationData['id'],
+            'submission_id' => $this->creationData['submission_id'],
+        ];
+    }
+
+    /**
+     * Get the array representation of the notification for the datatabase.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toDatabase($notifiable)
+    {
+        return [
+            'submission_id' => $this->creationData['submission_id'],
         ];
     }
 }

--- a/backend/app/Notifications/SubmissionCreation.php
+++ b/backend/app/Notifications/SubmissionCreation.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class SubmissionCreation extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public $afterCommit = true;
+
+    private $creationData;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($creationData)
+    {
+        $this->creationData = $creationData;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage())
+                    ->line($this->creationData['body'])
+                    ->action($this->creationData['action'], $this->creationData['url']);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'submission_id' => $this->creationData['id'],
+        ];
+    }
+}

--- a/backend/database/migrations/2021_11_03_174907_create_notifications_table.php
+++ b/backend/database/migrations/2021_11_03_174907_create_notifications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('notifications');
+    }
+}

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -28,6 +28,7 @@ class NotificationTest extends TestCase
         $user->notify(new SubmissionCreation($notification_data));
         $this->assertEquals(1, $user->notifications->count());
         $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+        $this->assertEquals($notification_data, $user->notifications->first()->data);
     }
 
     /**
@@ -43,9 +44,10 @@ class NotificationTest extends TestCase
             'submission_id' => 1001,
         ];
         Notification::send($users, new SubmissionCreation($notification_data));
-        $users->map(function ($user) {
+        $users->map(function ($user) use ($notification_data) {
             $this->assertEquals(1, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+            $this->assertEquals($notification_data, $user->notifications->first()->data);
         });
     }
 
@@ -72,6 +74,8 @@ class NotificationTest extends TestCase
         $this->assertEquals(2, $user->notifications->count());
         $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
         $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
+        $this->assertEquals($notification_data_1, $user->notifications->first()->data);
+        $this->assertEquals($notification_data_2, $user->notifications->last()->data);
     }
 
     /**
@@ -94,10 +98,12 @@ class NotificationTest extends TestCase
         ];
         Notification::send($users, new SubmissionCreation($notification_data_1));
         Notification::send($users, new SubmissionCreation($notification_data_2));
-        $users->map(function ($user) {
+        $users->map(function ($user) use ($notification_data_1, $notification_data_2) {
             $this->assertEquals(2, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
+            $this->assertEquals($notification_data_1, $user->notifications->first()->data);
+            $this->assertEquals($notification_data_2, $user->notifications->last()->data);
         });
     }
 

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -74,8 +74,18 @@ class NotificationTest extends TestCase
         $this->assertEquals(2, $user->notifications->count());
         $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
         $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
-        $this->assertEquals($notification_data_1, $user->notifications->first()->data);
-        $this->assertEquals($notification_data_2, $user->notifications->last()->data);
+        $notification_1 = $user->notifications
+            ->where('notifiable_type', "App\Models\User")
+            ->where('notifiable_id', $user->id)
+            ->where('data', $notification_data_1)
+            ->first();
+        $this->assertEquals($notification_data_1, $notification_1->data);
+        $notification_2 = $user->notifications
+            ->where('notifiable_type', "App\Models\User")
+            ->where('notifiable_id', $user->id)
+            ->where('data', $notification_data_2)
+            ->first();
+        $this->assertEquals($notification_data_2, $notification_2->data);
     }
 
     /**
@@ -102,8 +112,18 @@ class NotificationTest extends TestCase
             $this->assertEquals(2, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
-            $this->assertEquals($notification_data_1, $user->notifications->first()->data);
-            $this->assertEquals($notification_data_2, $user->notifications->last()->data);
+            $notification_1 = $user->notifications
+                ->where('notifiable_type', "App\Models\User")
+                ->where('notifiable_id', $user->id)
+                ->where('data', $notification_data_1)
+                ->first();
+            $this->assertEquals($notification_data_1, $notification_1->data);
+            $notification_2 = $user->notifications
+                ->where('notifiable_type', "App\Models\User")
+                ->where('notifiable_id', $user->id)
+                ->where('data', $notification_data_2)
+                ->first();
+            $this->assertEquals($notification_data_2, $notification_2->data);
         });
     }
 

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -40,12 +40,111 @@ class NotificationTest extends TestCase
             'body' => 'A submission has been created.',
             'action' => 'Visit CCR',
             'url' => '/',
-            'submission_id' => 1000,
+            'submission_id' => 1001,
         ];
         Notification::send($users, new SubmissionCreation($notification_data));
         $users->map(function($user) {
             $this->assertEquals(1, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function testMultipleSubmissionCreationNotificationsForAnIndividualUser()
+    {
+        $user = User::factory()->create();
+        $notification_data_1 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1002,
+        ];
+        $notification_data_2 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1003,
+        ];
+        $user->notify(new SubmissionCreation($notification_data_1));
+        $user->notify(new SubmissionCreation($notification_data_2));
+        $this->assertEquals(2, $user->notifications->count());
+        $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+        $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMultipleSubmissionCreationNotificationsForMultipleUsers()
+    {
+        $users = User::factory()->count(4)->create();
+        $notification_data_1 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1004,
+        ];
+        $notification_data_2 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1005,
+        ];
+        Notification::send($users, new SubmissionCreation($notification_data_1));
+        Notification::send($users, new SubmissionCreation($notification_data_2));
+        $users->map(function($user) {
+            $this->assertEquals(2, $user->notifications->count());
+            $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+            $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function testMarkingASubmissionCreationNotificationAsReadForAnIndividualUser()
+    {
+        $user = User::factory()->create();
+        $notification_data = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1006,
+        ];
+        $user->notify(new SubmissionCreation($notification_data));
+        $notification = $user->notifications->first();
+        $notification->markAsRead();
+        $this->assertEquals(0, $user->unreadNotifications->count());
+    }
+
+    /**
+     * @return void
+     */
+    public function testMarkingMultipleSubmissionCreationNotificationsAsReadForMultipleUsers()
+    {
+        $users = User::factory()->count(4)->create();
+        $notification_data_1 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1007,
+        ];
+        $notification_data_2 = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1008,
+        ];
+        Notification::send($users, new SubmissionCreation($notification_data_1));
+        Notification::send($users, new SubmissionCreation($notification_data_2));
+
+        $users->map(function($user) {
+            $user->notifications->map(function($notification) {
+                $notification->markAsRead();
+            });
+            $this->assertEquals(0, $user->unreadNotifications->count());
         });
     }
 }

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -43,7 +43,7 @@ class NotificationTest extends TestCase
             'submission_id' => 1001,
         ];
         Notification::send($users, new SubmissionCreation($notification_data));
-        $users->map(function($user) {
+        $users->map(function ($user) {
             $this->assertEquals(1, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
         });
@@ -94,7 +94,7 @@ class NotificationTest extends TestCase
         ];
         Notification::send($users, new SubmissionCreation($notification_data_1));
         Notification::send($users, new SubmissionCreation($notification_data_2));
-        $users->map(function($user) {
+        $users->map(function ($user) {
             $this->assertEquals(2, $user->notifications->count());
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
             $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->last()->type);
@@ -140,8 +140,8 @@ class NotificationTest extends TestCase
         Notification::send($users, new SubmissionCreation($notification_data_1));
         Notification::send($users, new SubmissionCreation($notification_data_2));
 
-        $users->map(function($user) {
-            $user->notifications->map(function($notification) {
+        $users->map(function ($user) {
+            $user->notifications->map(function ($notification) {
                 $notification->markAsRead();
             });
             $this->assertEquals(0, $user->unreadNotifications->count());

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\SubmissionCreation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class NotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return void
+     */
+    public function testSubmissionCreationNotificationForAnIndividualUser()
+    {
+        $user = User::factory()->create();
+        $notification_data = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1000,
+        ];
+        $user->notify(new SubmissionCreation($notification_data));
+        $this->assertEquals(1, $user->notifications->count());
+        $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSubmissionCreationNotificationForMultipleUsers()
+    {
+        $users = User::factory()->count(4)->create();
+        $notification_data = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1000,
+        ];
+        Notification::send($users, new SubmissionCreation($notification_data));
+        $users->map(function($user) {
+            $this->assertEquals(1, $user->notifications->count());
+            $this->assertEquals("App\Notifications\SubmissionCreation", $user->notifications->first()->type);
+        });
+    }
+}


### PR DESCRIPTION
This PR:

- Adds a new sample `SubmissionCreation` notification class 
- Adds a migration for the notifications table 
- Adds PHPUnit tests to assert that new functionality works 

Closes #685 