### PR TITLE
feat: Add Notifications to GraphQL Endpoint

### DIFF
--- a/backend/graphql/notification.graphql
+++ b/backend/graphql/notification.graphql
@@ -1,0 +1,9 @@
+"""
+A notification for an event
+"""
+type Notification {
+    id: ID!
+    notifiable: Notifiable! @morphTo
+}
+
+union Notifiable = Notification | User

--- a/backend/graphql/notification.graphql
+++ b/backend/graphql/notification.graphql
@@ -14,7 +14,7 @@ type NotificationData {
     body: String!
     action: String
     url: String
-    submission_id: ID!
+    submission_id: ID
 }
 
 union Notifiable = Notification | User

--- a/backend/graphql/notification.graphql
+++ b/backend/graphql/notification.graphql
@@ -4,6 +4,17 @@ A notification for an event
 type Notification {
     id: ID!
     notifiable: Notifiable! @morphTo
+    data: NotificationData
+}
+
+"""
+JSON data for a notification
+"""
+type NotificationData {
+    body: String!
+    action: String
+    url: String
+    submission_id: ID!
 }
 
 union Notifiable = Notification | User

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -1,4 +1,5 @@
 #import academic_profiles.graphql
+#import notification.graphql
 #import permission.graphql
 #import profile_metadata.graphql
 #import publication.graphql

--- a/backend/graphql/user.graphql
+++ b/backend/graphql/user.graphql
@@ -14,5 +14,5 @@ type User {
     profile_metadata: ProfileMetadata
     submissions: [Submission]! @belongsToMany
     pivot: SubmissionUser
-    notifications: [Notification]! @hasMany(type: PAGINATOR)
+    notifications: [Notification]! @hasMany(type: PAGINATOR) @whereAuth(relation: "notifiable")
 }

--- a/backend/graphql/user.graphql
+++ b/backend/graphql/user.graphql
@@ -14,4 +14,5 @@ type User {
     profile_metadata: ProfileMetadata
     submissions: [Submission]! @belongsToMany
     pivot: SubmissionUser
+    notifications: [Notification]! @morphMany
 }

--- a/backend/graphql/user.graphql
+++ b/backend/graphql/user.graphql
@@ -14,5 +14,5 @@ type User {
     profile_metadata: ProfileMetadata
     submissions: [Submission]! @belongsToMany
     pivot: SubmissionUser
-    notifications: [Notification]! @morphMany
+    notifications: [Notification]! @hasMany(type: PAGINATOR)
 }

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -7,10 +7,12 @@ use App\Models\User;
 use App\Notifications\SubmissionCreation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
 {
+    use MakesGraphQLRequests;
     use RefreshDatabase;
 
     /**
@@ -172,5 +174,69 @@ class NotificationTest extends TestCase
             });
             $this->assertEquals(0, $user->unreadNotifications->count());
         });
+    }
+
+    /**
+     * @return void
+     */
+    public function testNotificationsCanOnlyBeQueriedForOneself()
+    {
+        /** @var User $user_1 */
+        $user_1 = User::factory()->create();
+        $user_2 = User::factory()->create();
+        $this->actingAs($user_1);
+        $notification_data = [
+            'body' => 'A submission has been created.',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'submission_id' => 1000,
+        ];
+        $user_1->notify(new SubmissionCreation($notification_data));
+        $user_2->notify(new SubmissionCreation($notification_data));
+        $response = $this->graphQL(
+            'query GetUsers {
+                userSearch {
+                    data {
+                        id
+                        notifications (first: 10, page: 1) {
+                            data {
+                                body
+                                submission_id
+                            }
+                        }
+                    }
+                }
+            }'
+        );
+        $expected_data = [
+            'data' => [
+                'userSearch' => [
+                    'data' => [
+                        [
+                            'id' => $user_1->id,
+                            'notifications' => [
+                                'data' => [
+                                    [
+                                        'data' => [
+                                            [
+                                                'body' => 'A submission has been created',
+                                                'submission_id' => '1000',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => $user_2->id,
+                            'notifications' => [
+                                'data' => [ ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $response->assertJson($expected_data);
     }
 }

--- a/backend/tests/Feature/NotificationTest.php
+++ b/backend/tests/Feature/NotificationTest.php
@@ -200,8 +200,10 @@ class NotificationTest extends TestCase
                         id
                         notifications (first: 10, page: 1) {
                             data {
-                                body
-                                submission_id
+                                data {
+                                    body
+                                    submission_id
+                                }
                             }
                         }
                     }
@@ -213,22 +215,20 @@ class NotificationTest extends TestCase
                 'userSearch' => [
                     'data' => [
                         [
-                            'id' => $user_1->id,
+                            'id' => (string)$user_1->id,
                             'notifications' => [
                                 'data' => [
                                     [
                                         'data' => [
-                                            [
-                                                'body' => 'A submission has been created',
-                                                'submission_id' => '1000',
-                                            ],
+                                            'body' => 'A submission has been created.',
+                                            'submission_id' => '1000',
                                         ],
                                     ],
                                 ],
                             ],
                         ],
                         [
-                            'id' => $user_2->id,
+                            'id' => (string)$user_2->id,
                             'notifications' => [
                                 'data' => [ ],
                             ],


### PR DESCRIPTION
This PR:

* Adds the Notifications type to the GraphQL schema
* Adds a `notifications` property to the `User` type in GraphQL comprised of all the user's notifications
    - This will only return data for the currently authenticated users
    - The notification data can be optionally paginated

Closes #717