### PR TITLE
feat: Update Lando Version in GitHub Action

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Cypress.io"
     steps:
       - name: Install Lando
-        run: wget -nv https://files.lando.dev/installer/lando-x64-stable.deb && sudo dpkg -i --ignore-depends=docker-ce lando-stable.deb
+        run: wget -nv https://files.lando.dev/installer/lando-x64-stable.deb && sudo dpkg -i --ignore-depends=docker-ce lando-x64-stable.deb
       - uses: actions/checkout@v2
       - name: Cache Composer packages
         id: composer-cache

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Cypress.io"
     steps:
       - name: Install Lando
-        run: wget -nv https://files.devwithlando.io/lando-stable.deb && sudo dpkg -i --ignore-depends=docker-ce lando-stable.deb
+        run: wget -nv https://files.lando.dev/installer/lando-x64-stable.deb && sudo dpkg -i --ignore-depends=docker-ce lando-stable.deb
       - uses: actions/checkout@v2
       - name: Cache Composer packages
         id: composer-cache


### PR DESCRIPTION
This PR addresses the "Update Available!" warnings that appear whenever Lando runs a task within a GitHub Action. This also resolves the "unsupported version of DOCKER COMPOSE" warnings as well.

Old Logs:

<img width="1024" alt="old-docker" src="https://user-images.githubusercontent.com/2668987/146622116-a8e463f3-c3d9-4082-b19d-5843f94ae526.png">
<img width="1012" alt="old-lando" src="https://user-images.githubusercontent.com/2668987/146622134-29776aa5-4a1f-43f1-bbca-aa86ee431671.png">

New Logs:

<img width="1022" alt="new-lando" src="https://user-images.githubusercontent.com/2668987/146622146-7a50840c-40f7-4908-bdbe-84ffd41f4850.png">

