### PR TITLE
feat: Populate Notification Data Upon Submission Creation

### DIFF
--- a/backend/app/Events/SubmissionCreated.php
+++ b/backend/app/Events/SubmissionCreated.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Events;
 
+use App\Models\Submission;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -15,16 +16,17 @@ class SubmissionCreated
     use SerializesModels;
 
     /**
-     * @var \App\Models\Submission $submission
+     * @var App\Models\Submission $submission
      */
     public $submission;
 
     /**
      * Create a new event instance.
      *
+     * @param App\Models\Submission $submission
      * @return void
      */
-    public function __construct($submission)
+    public function __construct(Submission $submission)
     {
         $this->submission = $submission;
     }

--- a/backend/app/Events/SubmissionCreated.php
+++ b/backend/app/Events/SubmissionCreated.php
@@ -16,14 +16,14 @@ class SubmissionCreated
     use SerializesModels;
 
     /**
-     * @var App\Models\Submission $submission
+     * @var \App\Models\Submission $submission
      */
     public $submission;
 
     /**
      * Create a new event instance.
      *
-     * @param App\Models\Submission $submission
+     * @param \App\Models\Submission $submission
      * @return void
      */
     public function __construct(Submission $submission)

--- a/backend/app/Events/SubmissionCreated.php
+++ b/backend/app/Events/SubmissionCreated.php
@@ -14,6 +14,9 @@ class SubmissionCreated
     use InteractsWithSockets;
     use SerializesModels;
 
+    /**
+     * @var \App\Models\Submission $submission
+     */
     public $submission;
 
     /**

--- a/backend/app/Events/SubmissionCreated.php
+++ b/backend/app/Events/SubmissionCreated.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SubmissionCreated
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public $submission;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($submission)
+    {
+        $this->submission = $submission;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Models\Role;
+use App\Notifications\SubmissionCreated;
+use Illuminate\Support\Facades\Notification;
+
+class EmailUsersAboutCreatedSubmission
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * TODO: Refactor the user data to use the "created_by" property once it's added to submissions
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $submitters = $event->submission->users->filter(function ($user) {
+            return $user->pivot->role_id == Role::SUBMITTER_ROLE_ID;
+        });
+        $notification_data = [
+            'submission' => [
+                'id' => $event->submission->id,
+                'title' => $event->submission->title,
+            ],
+            'user' => [
+                'id' => $submitters->first()->id,
+                'username' => $submitters->first()->username,
+                'name' => $submitters->first()->name,
+            ],
+            'publication' => [
+                'id' => $event->submission->publication->id,
+                'name' => $event->submission->publication->name,
+            ],
+            'type' => 'submission.created',
+            'action' => 'Visit CCR',
+            'url' => '/',
+            'body' => 'A submission has been created.',
+        ];
+        // Notify submitters and editors
+        Notification::send($submitters, new SubmissionCreated($notification_data));
+        $editors = $event->submission->publication->users->filter(function ($user) {
+            return $user->pivot->role_id == Role::EDITOR_ROLE_ID;
+        });
+        Notification::send($editors, new SubmissionCreated($notification_data));
+    }
+}

--- a/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
@@ -5,6 +5,7 @@ namespace App\Listeners;
 
 use App\Models\Role;
 use App\Notifications\SubmissionCreated;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Notification;
 
 class EmailUsersAboutCreatedSubmission
@@ -48,7 +49,7 @@ class EmailUsersAboutCreatedSubmission
             ],
             'type' => 'submission.created',
             'action' => 'Visit CCR',
-            'url' => '/',
+            'url' => url('/submission/'.$event->submission->id),
             'body' => 'A submission has been created.',
         ];
         // Notify submitters and editors

--- a/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
@@ -5,7 +5,6 @@ namespace App\Listeners;
 
 use App\Models\Role;
 use App\Notifications\SubmissionCreated;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Notification;
 
 class EmailUsersAboutCreatedSubmission
@@ -49,7 +48,7 @@ class EmailUsersAboutCreatedSubmission
             ],
             'type' => 'submission.created',
             'action' => 'Review Submission',
-            'url' => url('/submission/'.$event->submission->id),
+            'url' => url('/submission/' . $event->submission->id),
             'body' => 'A submission has been created.',
         ];
         // Notify submitters and editors

--- a/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/EmailUsersAboutCreatedSubmission.php
@@ -48,7 +48,7 @@ class EmailUsersAboutCreatedSubmission
                 'name' => $event->submission->publication->name,
             ],
             'type' => 'submission.created',
-            'action' => 'Visit CCR',
+            'action' => 'Review Submission',
             'url' => url('/submission/'.$event->submission->id),
             'body' => 'A submission has been created.',
         ];

--- a/backend/app/Listeners/NotifyUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/NotifyUsersAboutCreatedSubmission.php
@@ -7,7 +7,7 @@ use App\Models\Role;
 use App\Notifications\SubmissionCreated;
 use Illuminate\Support\Facades\Notification;
 
-class EmailUsersAboutCreatedSubmission
+class NotifyUsersAboutCreatedSubmission
 {
     /**
      * Create the event listener.

--- a/backend/app/Listeners/NotifyUsersAboutCreatedSubmission.php
+++ b/backend/app/Listeners/NotifyUsersAboutCreatedSubmission.php
@@ -10,16 +10,6 @@ use Illuminate\Support\Facades\Notification;
 class NotifyUsersAboutCreatedSubmission
 {
     /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event.
      *
      * TODO: Refactor the user data to use the "created_by" property once it's added to submissions

--- a/backend/app/Notifications/SubmissionCreated.php
+++ b/backend/app/Notifications/SubmissionCreated.php
@@ -36,7 +36,10 @@ class SubmissionCreated extends Notification implements ShouldQueue
      */
     public function via()
     {
-        return ['database'];
+        return [
+            'database',
+            'mail',
+        ];
     }
 
     /**

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Events\SubmissionCreated;
+use App\Listeners\EmailUsersAboutCreatedSubmission;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -17,6 +19,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        SubmissionCreated::class => [
+            EmailUsersAboutCreatedSubmission::class,
         ],
     ];
 

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 use App\Events\SubmissionCreated;
-use App\Listeners\EmailUsersAboutCreatedSubmission;
+use App\Listeners\NotifyUsersAboutCreatedSubmission;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -21,7 +21,7 @@ class EventServiceProvider extends ServiceProvider
             SendEmailVerificationNotification::class,
         ],
         SubmissionCreated::class => [
-            EmailUsersAboutCreatedSubmission::class,
+            NotifyUsersAboutCreatedSubmission::class,
         ],
     ];
 

--- a/backend/graphql/schema.graphql
+++ b/backend/graphql/schema.graphql
@@ -96,6 +96,7 @@ type Mutation {
 
     "Create a new submission under a publication"
     createSubmission(input: CreateSubmissionInput! @spread): Submission!
+        @event(dispatch: "App\\Events\\SubmissionCreated")
 
     "Create an association between a user, role, and submission"
     createSubmissionUser(submission_user: CreateSubmissionUserInput! @spread): SubmissionUser!

--- a/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
+++ b/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Events\SubmissionCreated;
+use App\Listeners\EmailUsersAboutCreatedSubmission;
+use App\Models\Publication;
+use App\Models\Submission;
+use App\Models\User;
+use App\Notifications\SubmissionCreated as NotificationsSubmissionCreated;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SubmissionCreatedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return void
+     */
+    public function testThatNotificationsAreSent()
+    {
+        Notification::fake();
+        Mail::fake();
+
+        $user = User::factory()->create();
+        $publication = Publication::factory()->create();
+        $submission = Submission::factory()
+            ->hasAttached(
+                $user,
+                [
+                    'role_id' => 6,
+                ]
+            )
+            ->create([
+                'publication_id' => $publication->id,
+            ]);
+        $event = new SubmissionCreated($submission);
+        $listener = new EmailUsersAboutCreatedSubmission();
+        $listener->handle($event);
+
+        Notification::assertSentTo($user, NotificationsSubmissionCreated::class);
+        Mail::assertSent(NotificationsSubmissionCreated::class);
+    }
+}

--- a/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
+++ b/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Notifications;
 
 use App\Events\SubmissionCreated;
-use App\Listeners\EmailUsersAboutCreatedSubmission;
+use App\Listeners\NotifyUsersAboutCreatedSubmission;
 use App\Models\Publication;
 use App\Models\Submission;
 use App\Models\User;
@@ -44,7 +44,7 @@ class SubmissionCreatedTest extends TestCase
                 'publication_id' => $publication->id,
             ]);
         $event = new SubmissionCreated($submission);
-        $listener = new EmailUsersAboutCreatedSubmission();
+        $listener = new NotifyUsersAboutCreatedSubmission();
         $listener->handle($event);
         Notification::assertSentTo($submitter, NotificationsSubmissionCreated::class);
         Notification::assertSentTo($editor, NotificationsSubmissionCreated::class);

--- a/client/src/components/molecules/NotificationPopup.vue
+++ b/client/src/components/molecules/NotificationPopup.vue
@@ -11,6 +11,7 @@
     <q-badge
       v-if="hasUnreadNotifications"
       ref="notification_indicator"
+      data-cy="notification_indicator"
       role="presentation"
       floating
       color="light-blue-3"

--- a/client/test/cypress/integration/submissions.spec.js
+++ b/client/test/cypress/integration/submissions.spec.js
@@ -31,6 +31,8 @@ describe("Submissions", () => {
         "nested-interactive": { enabled: false },
       },
     })
+    cy.reload()
+    cy.dataCy("notification_indicator").should("be.visible")
   })
 
   it("prevents submission creation when the title exceeds the maximum length", () => {


### PR DESCRIPTION
This PR:

* Adds functionality for sending an email and in-app notification to users upon the creation of a submission. Those users are:
    - The submitter of the submission
    - Any editor of the publication associated with the submission
* Adds Cypress and PHPUnit testing to ensure correct behavior

Closes #746 