### PR TITLE
feat: Add Submission Statuses

### DIFF
--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -38,6 +38,15 @@ class Submission extends Model
     ];
 
     /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = [
+        'status_name',
+    ];
+
+    /**
      * The publication that the submission belongs to
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -67,5 +76,27 @@ class Submission extends Model
     public function files(): HasMany
     {
         return $this->hasMany(SubmissionFile::class);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatusNameAttribute()
+    {
+        $statuses = [
+            1 => 'INITIALLY_SUBMITTED',
+            2 => 'AWAITING_RESUBMISSION',
+            3 => 'RESUBMITTED',
+            4 => 'AWAITING_REVIEW',
+            5 => 'REJECTED',
+            6 => 'ACCEPTED_AS_FINAL',
+            7 => 'EXPIRED',
+            8 => 'UNDER_REVIEW',
+            9 => 'AWAITING_DECISION',
+            10 => 'AWAITING_REVISION',
+            11 => 'ARCHIVED',
+            12 => 'DELETED',
+        ];
+        return $statuses[(int)$this->status];
     }
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -13,6 +13,19 @@ class Submission extends Model
 {
     use HasFactory;
 
+    public const INITIALLY_SUBMITTED = 1;
+    public const AWAITING_RESUBMISSION = 2;
+    public const RESUBMITTED = 3;
+    public const AWAITING_REVIEW = 4;
+    public const REJECTED = 5;
+    public const ACCEPTED_AS_FINAL = 6;
+    public const EXPIRED = 7;
+    public const UNDER_REVIEW = 8;
+    public const AWAITING_DECISION = 9;
+    public const AWAITING_REVISION = 10;
+    public const ARCHIVED = 11;
+    public const DELETED = 12;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -22,15 +35,6 @@ class Submission extends Model
         'title',
         'publication_id',
         'status',
-    ];
-
-    /**
-     * The accessors to append to the model's array form.
-     *
-     * @var array
-     */
-    protected $appends = [
-        'status_name',
     ];
 
     /**
@@ -63,28 +67,5 @@ class Submission extends Model
     public function files(): HasMany
     {
         return $this->hasMany(SubmissionFile::class);
-    }
-
-    /**
-     * @return string
-     */
-    public function getStatusNameAttribute()
-    {
-        $statuses = [
-            1 => 'Initially Submitted',
-            2 => 'Awaiting Resubmission',
-            3 => 'Resubmitted',
-            4 => 'Awaiting Review',
-            5 => 'Rejected',
-            6 => 'Accepted as Final',
-            7 => 'Expired',
-            8 => 'Under Review',
-            9 => 'Awaiting Decision',
-            10 => 'Awaiting Revision',
-            11 => 'Archived',
-            12 => 'Deleted',
-        ];
-
-        return $statuses[(int)$this->status];
     }
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -97,6 +97,7 @@ class Submission extends Model
             11 => 'ARCHIVED',
             12 => 'DELETED',
         ];
+
         return $statuses[(int)$this->status];
     }
 }

--- a/backend/app/Models/Submission.php
+++ b/backend/app/Models/Submission.php
@@ -21,6 +21,16 @@ class Submission extends Model
     protected $fillable = [
         'title',
         'publication_id',
+        'status',
+    ];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = [
+        'status_name',
     ];
 
     /**
@@ -53,5 +63,28 @@ class Submission extends Model
     public function files(): HasMany
     {
         return $this->hasMany(SubmissionFile::class);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatusNameAttribute()
+    {
+        $statuses = [
+            1 => 'Initially Submitted',
+            2 => 'Awaiting Resubmission',
+            3 => 'Resubmitted',
+            4 => 'Awaiting Review',
+            5 => 'Rejected',
+            6 => 'Accepted as Final',
+            7 => 'Expired',
+            8 => 'Under Review',
+            9 => 'Awaiting Decision',
+            10 => 'Awaiting Revision',
+            11 => 'Archived',
+            12 => 'Deleted',
+        ];
+
+        return $statuses[(int)$this->status];
     }
 }

--- a/backend/database/factories/SubmissionFactory.php
+++ b/backend/database/factories/SubmissionFactory.php
@@ -26,6 +26,7 @@ class SubmissionFactory extends Factory
         return [
             'title' => $this->faker->sentence(10, true),
             'publication_id' => Publication::factory(),
+            'status' => 1,
         ];
     }
 }

--- a/backend/database/migrations/2022_01_13_184123_add_submission_statuses.php
+++ b/backend/database/migrations/2022_01_13_184123_add_submission_statuses.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSubmissionStatuses extends Migration
+{
+    /** @var string $table_name */
+    private $table_name = 'submissions';
+
+    /** @var string $column_name */
+    private $column_name = 'status';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table($this->table_name, function (Blueprint $table) {
+            $table->tinyInteger($this->column_name)->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if(Schema::hasColumn($this->table_name, $this->__visibility_flag)) {
+            Schema::table($this->table_name, function (Blueprint $table) {
+                $table->dropColumn($this->column_name);
+            });
+        }
+    }
+}

--- a/backend/database/migrations/2022_01_13_184123_add_submission_statuses.php
+++ b/backend/database/migrations/2022_01_13_184123_add_submission_statuses.php
@@ -31,7 +31,7 @@ class AddSubmissionStatuses extends Migration
      */
     public function down()
     {
-        if(Schema::hasColumn($this->table_name, $this->__visibility_flag)) {
+        if (Schema::hasColumn($this->table_name, $this->column_name)) {
             Schema::table($this->table_name, function (Blueprint $table) {
                 $table->dropColumn($this->column_name);
             });

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -10,8 +10,7 @@ type Submission {
     users: [User!]! @belongsToMany
     files: [SubmissionFile]! @hasMany
     pivot: SubmissionUser
-    status: Int!
-    status_name: String!
+    status: SubmissionStatus!
 }
 
 """
@@ -31,4 +30,19 @@ type SubmissionFile {
     id: ID!
     submission_id: ID!
     file_upload: String!
+}
+
+enum SubmissionStatus {
+    INITIALLY_SUBMITTED
+    AWAITING_RESUBMISSION
+    RESUBMITTED
+    AWAITING_REVIEW
+    REJECTED
+    ACCEPTED_AS_FINAL
+    EXPIRED
+    UNDER_REVIEW
+    AWAITING_DECISION
+    AWAITING_REVISION
+    ARCHIVED
+    DELETED
 }

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -10,6 +10,8 @@ type Submission {
     users: [User!]! @belongsToMany
     files: [SubmissionFile]! @hasMany
     pivot: SubmissionUser
+    status: Int!
+    status_name: String!
 }
 
 """

--- a/backend/graphql/submission.graphql
+++ b/backend/graphql/submission.graphql
@@ -33,16 +33,16 @@ type SubmissionFile {
 }
 
 enum SubmissionStatus {
-    INITIALLY_SUBMITTED
-    AWAITING_RESUBMISSION
-    RESUBMITTED
-    AWAITING_REVIEW
-    REJECTED
-    ACCEPTED_AS_FINAL
-    EXPIRED
-    UNDER_REVIEW
-    AWAITING_DECISION
-    AWAITING_REVISION
-    ARCHIVED
-    DELETED
+    INITIALLY_SUBMITTED @enum(value: 1)
+    AWAITING_RESUBMISSION @enum(value: 2)
+    RESUBMITTED @enum(value: 3)
+    AWAITING_REVIEW @enum(value: 4)
+    REJECTED @enum(value: 5)
+    ACCEPTED_AS_FINAL @enum(value: 6)
+    EXPIRED @enum(value: 7)
+    UNDER_REVIEW @enum(value: 8)
+    AWAITING_DECISION @enum(value: 9)
+    AWAITING_REVISION @enum(value: 10)
+    ARCHIVED @enum(value: 11)
+    DELETED @enum(value: 12)
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -827,11 +827,11 @@ class SubmissionTest extends TestCase
     public function testCreateSubmissionUserViaMutationAsAReviewCoordinator(array $case)
     {
         $publication = Publication::factory()->create();
+        $submitter = User::factory()->create();
         /** @var User $review_coordinator */
         $review_coordinator = User::factory()->create();
         $this->actingAs($review_coordinator);
         $user_to_be_assigned = User::factory()->create();
-        $submitter = User::factory()->create();
         $submission = Submission::factory()
             ->for($publication)
             ->hasAttached($submitter, ['role_id' => Role::SUBMITTER_ROLE_ID])
@@ -912,7 +912,7 @@ class SubmissionTest extends TestCase
         }
         $query_response_json = $query_response->decodeResponseJson();
         $query_response_value = AssertableJson::fromAssertableJsonString($query_response_json);
-        $this->assertEquals($query_response_value->toArray()['data'], $expected_query_response);
+        $this->assertEquals($expected_query_response, $query_response_value->toArray()['data']);
     }
 
     /**

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -1437,9 +1437,9 @@ class SubmissionTest extends TestCase
     {
         $submission = Submission::factory()->create();
         $this->assertEquals(Submission::INITIALLY_SUBMITTED, $submission->status);
-        $this->assertEquals("INITIALLY_SUBMITTED", $submission->status_name);
+        $this->assertEquals('INITIALLY_SUBMITTED', $submission->status_name);
         $submission->status = Submission::AWAITING_REVIEW;
         $this->assertEquals(Submission::AWAITING_REVIEW, $submission->status);
-        $this->assertEquals("AWAITING_REVIEW", $submission->status_name);
+        $this->assertEquals('AWAITING_REVIEW', $submission->status_name);
     }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -1436,9 +1436,8 @@ class SubmissionTest extends TestCase
     public function testThatTheStatusOfASubmissionCanBeRetrievedAndChangedViaEloquent()
     {
         $submission = Submission::factory()->create();
-        $this->assertEquals(1, $submission->status);
-        $submission->status = 4;
-        $this->assertEquals(4, $submission->status);
-        $this->assertEquals('Awaiting Review', $submission->status_name);
+        $this->assertEquals(Submission::INITIALLY_SUBMITTED, $submission->status);
+        $submission->status = Submission::AWAITING_REVIEW;
+        $this->assertEquals(Submission::AWAITING_REVIEW, $submission->status);
     }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -1429,4 +1429,16 @@ class SubmissionTest extends TestCase
         $expected_mutation_response = null;
         $response->assertJsonPath('data', $expected_mutation_response);
     }
+
+    /**
+     * @return void
+     */
+    public function testThatTheStatusOfASubmissionCanBeRetrievedAndChangedViaEloquent()
+    {
+        $submission = Submission::factory()->create();
+        $this->assertEquals(1, $submission->status);
+        $submission->status = 4;
+        $this->assertEquals(4, $submission->status);
+        $this->assertEquals('Awaiting Review', $submission->status_name);
+    }
 }

--- a/backend/tests/Feature/SubmissionTest.php
+++ b/backend/tests/Feature/SubmissionTest.php
@@ -1433,11 +1433,13 @@ class SubmissionTest extends TestCase
     /**
      * @return void
      */
-    public function testThatTheStatusOfASubmissionCanBeRetrievedAndChangedViaEloquent()
+    public function testSubmissionStatusCanBeRetrievedAndChangedViaEloquent()
     {
         $submission = Submission::factory()->create();
         $this->assertEquals(Submission::INITIALLY_SUBMITTED, $submission->status);
+        $this->assertEquals("INITIALLY_SUBMITTED", $submission->status_name);
         $submission->status = Submission::AWAITING_REVIEW;
         $this->assertEquals(Submission::AWAITING_REVIEW, $submission->status);
+        $this->assertEquals("AWAITING_REVIEW", $submission->status_name);
     }
 }


### PR DESCRIPTION
This PR:

* Adds `status` and `status_name` properties to the submissions model
* Adds a migration for the new column in the submissions table
* Bonus: Fixes an emergent bug with ordering (again somehow!) in the `testCreateSubmissionUserViaMutationAsAReviewCoordinator()` method of `SubmissionTest.php`

Closes #755 