### PR TITLE
test(client): add tests for pagination composable

### DIFF
--- a/client/src/graphql/fragments.js
+++ b/client/src/graphql/fragments.js
@@ -36,3 +36,12 @@ export const _CURRENT_USER_FIELDS = gql`
     }
   }
 `
+
+export const _PAGINATION_FIELDS = gql`
+  fragment paginationFields on PaginatorInfo {
+    count
+    currentPage
+    lastPage
+    perPage
+  }
+`

--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -1,5 +1,9 @@
 import gql from "graphql-tag"
-import { _CURRENT_USER_FIELDS, _PROFILE_METADATA_FIELDS } from "./fragments"
+import {
+  _CURRENT_USER_FIELDS,
+  _PAGINATION_FIELDS,
+  _PROFILE_METADATA_FIELDS,
+} from "./fragments"
 
 export const CURRENT_USER = gql`
   ${_CURRENT_USER_FIELDS}
@@ -27,10 +31,7 @@ export const CURRENT_USER_NOTIFICATIONS = gql`
       id
       notifications(first: 10, page: $page) {
         paginatorInfo {
-          count
-          currentPage
-          lastPage
-          perPage
+          ...paginationFields
         }
         data {
           id
@@ -52,6 +53,7 @@ export const CURRENT_USER_NOTIFICATIONS = gql`
       }
     }
   }
+  ${_PAGINATION_FIELDS}
 `
 export const CURRENT_USER_SUBMISSIONS = gql`
   query CurrentUserSubmission {
@@ -72,10 +74,7 @@ export const GET_USERS = gql`
   query GetUsers($page: Int) {
     userSearch(page: $page) {
       paginatorInfo {
-        count
-        currentPage
-        lastPage
-        perPage
+        ...paginationFields
       }
       data {
         id
@@ -85,6 +84,7 @@ export const GET_USERS = gql`
       }
     }
   }
+  ${_PAGINATION_FIELDS}
 `
 
 export const GET_USER = gql`
@@ -104,10 +104,7 @@ export const SEARCH_USERS = gql`
   query SearchUsers($term: String, $page: Int) {
     userSearch(term: $term, page: $page) {
       paginatorInfo {
-        count
-        currentPage
-        lastPage
-        perPage
+        ...paginationFields
       }
       data {
         id
@@ -117,16 +114,14 @@ export const SEARCH_USERS = gql`
       }
     }
   }
+  ${_PAGINATION_FIELDS}
 `
 
 export const GET_PUBLICATIONS = gql`
   query GetPublications($page: Int) {
     publications(page: $page) {
       paginatorInfo {
-        count
-        currentPage
-        lastPage
-        perPage
+        ...paginationFields
       }
       data {
         id
@@ -134,16 +129,14 @@ export const GET_PUBLICATIONS = gql`
       }
     }
   }
+  ${_PAGINATION_FIELDS}
 `
 
 export const GET_SUBMISSIONS = gql`
   query GetSubmissions($page: Int) {
     submissions(page: $page) {
       paginatorInfo {
-        count
-        currentPage
-        lastPage
-        perPage
+        ...paginationFields
       }
       data {
         id
@@ -158,6 +151,7 @@ export const GET_SUBMISSIONS = gql`
       }
     }
   }
+  ${_PAGINATION_FIELDS}
 `
 
 export const GET_SUBMISSION = gql`

--- a/client/src/pages/Admin/Publications.jest.spec.js
+++ b/client/src/pages/Admin/Publications.jest.spec.js
@@ -65,6 +65,7 @@ describe("publications page mount", () => {
             { id: "4", name: "Sample Jest Publication 4" },
           ],
           paginatorInfo: {
+            __typename: "PaginatorInfo",
             count: 4,
             currentPage: 1,
             lastPage: 1,

--- a/client/src/pages/Admin/UsersIndex.jest.spec.js
+++ b/client/src/pages/Admin/UsersIndex.jest.spec.js
@@ -50,6 +50,7 @@ describe("User Index page mount", () => {
             },
           ],
           paginatorInfo: {
+            __typename: "PaginatorInfo",
             count: 2,
             currentPage: 1,
             lastPage: 1,

--- a/client/src/pages/Publications.jest.spec.js
+++ b/client/src/pages/Publications.jest.spec.js
@@ -23,6 +23,7 @@ describe("publications page mount", () => {
           { id: "4", name: "Sample Jest Publication 4" },
         ],
         paginatorInfo: {
+          __typename: "PaginatorInfo",
           count: 4,
           currentPage: 1,
           lastPage: 1,

--- a/client/src/pages/Submissions.jest.spec.js
+++ b/client/src/pages/Submissions.jest.spec.js
@@ -47,6 +47,7 @@ describe("submissions page mount", () => {
       data: {
         publications: {
           paginatorInfo: {
+            __typename: "PaginatorInfo",
             count: 1,
             currentPage: 1,
             lastPage: 1,
@@ -63,6 +64,7 @@ describe("submissions page mount", () => {
       data: {
         submissions: {
           paginatorInfo: {
+            __typename: "PaginatorInfo",
             count: 5,
             currentPage: 1,
             lastPage: 1,

--- a/client/src/use/pagination.jest.spec.js
+++ b/client/src/use/pagination.jest.spec.js
@@ -64,26 +64,36 @@ describe("useCurrentUser composable", () => {
         .map((_, v) => ({ id: v, name: `Pub ${v}` })),
     ]
 
-    queryMock.mockResolvedValue({
+    const mockResponseData = (data = []) => ({
       data: {
         publications: {
           paginatorInfo: {
             __typename: "PaginatorInfo",
-            count: 0,
+            count: data.length,
             currentPage: 1,
             lastPage: 1,
             perPage: 10,
           },
-          data: [...returnData],
+          data,
         },
       },
     })
 
+    queryMock.mockResolvedValue(mockResponseData(returnData))
     const result = await mountComposable()
 
     expect(queryMock).toHaveBeenCalled()
     expect(isRef(result.data)).toBe(true)
     expect(result.data.value).toHaveLength(5)
+
+    //Resolve with empty data array.
+    queryMock.mockResolvedValue(mockResponseData())
+
+    //Update page to trigger a new query
+    result.updatePage(2)
+    await flushPromises()
+
+    expect(result.data.value).toHaveLength(0)
   })
 
   test("can override variables", async () => {

--- a/client/src/use/pagination.jest.spec.js
+++ b/client/src/use/pagination.jest.spec.js
@@ -1,0 +1,132 @@
+import { mount } from "vue-composable-tester"
+import { createMockClient } from "mock-apollo-client"
+import { usePagination } from "./pagination"
+import { DefaultApolloClient } from "@vue/apollo-composable"
+import { provide } from "vue"
+import { GET_PUBLICATIONS } from "src/graphql/queries"
+import flushPromises from "flush-promises"
+import { isRef } from "vue"
+
+describe("useCurrentUser composable", () => {
+  const mockClient = createMockClient({
+    defaultOptions: { watchQuery: { fetchPolicy: "network-only" } },
+  })
+  const mountComposable = async (options) => {
+    const { result } = mount(() => usePagination(GET_PUBLICATIONS, options), {
+      provider: () => {
+        provide(DefaultApolloClient, mockClient)
+      },
+    })
+    await flushPromises()
+    return result
+  }
+
+  const queryMock = jest.fn()
+  mockClient.setRequestHandler(GET_PUBLICATIONS, queryMock)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test("current page functionality", async () => {
+    queryMock.mockResolvedValue({
+      data: {
+        publications: {
+          paginatorInfo: {
+            __typename: "PaginatorInfo",
+            count: 0,
+            currentPage: 1,
+            lastPage: 1,
+            perPage: 10,
+          },
+          data: [],
+        },
+      },
+    })
+
+    const result = await mountComposable()
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }))
+    expect(isRef(result.currentPage)).toBe(true)
+    expect(result.currentPage.value).toBe(1)
+    queryMock.mockClear()
+
+    result.updatePage(2)
+    await flushPromises()
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }))
+    expect(result.currentPage.value).toBe(2)
+  })
+
+  test("data functionality", async () => {
+    const returnData = [
+      ...Array(5)
+        .fill(0)
+        .map((_, v) => ({ id: v, name: `Pub ${v}` })),
+    ]
+
+    queryMock.mockResolvedValue({
+      data: {
+        publications: {
+          paginatorInfo: {
+            __typename: "PaginatorInfo",
+            count: 0,
+            currentPage: 1,
+            lastPage: 1,
+            perPage: 10,
+          },
+          data: [...returnData],
+        },
+      },
+    })
+
+    const result = await mountComposable()
+
+    expect(queryMock).toHaveBeenCalled()
+    expect(isRef(result.data)).toBe(true)
+    expect(result.data.value).toHaveLength(5)
+  })
+
+  test("can override variables", async () => {
+    queryMock.mockResolvedValue({
+      data: {
+        publications: {
+          paginatorInfo: {
+            __typename: "PaginatorInfo",
+            count: 0,
+            currentPage: 1,
+            lastPage: 1,
+            perPage: 10,
+          },
+          data: [],
+        },
+      },
+    })
+
+    await mountComposable({ variables: { page: 2 } })
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }))
+  })
+
+  test("pagination component binds", async () => {
+    queryMock.mockResolvedValue({
+      data: {
+        publications: {
+          paginatorInfo: {
+            __typename: "PaginatorInfo",
+            count: 0,
+            currentPage: 1,
+            lastPage: 4,
+            perPage: 10,
+          },
+          data: [],
+        },
+      },
+    })
+
+    const result = await mountComposable()
+
+    expect(isRef(result.binds)).toBe(true)
+    const binds = result.binds.value
+    expect(binds).toEqual({ modelValue: 1, min: 1, max: 4 })
+  })
+})


### PR DESCRIPTION
This PR: 
* add unit tests for pagination composable
* creates graphql fragment for pagination fields
* Implements fragment for existing queries
* Add type names to existing mocked paginated queries