### PR TITLE
fix(client): add client side validation to account profile edit page

### DIFF
--- a/client/src/components/atoms/VQInput.jest.spec.js
+++ b/client/src/components/atoms/VQInput.jest.spec.js
@@ -9,11 +9,13 @@ import { useFormState } from "src/use/forms"
 
 jest.mock("vue-i18n", () => ({
   useI18n: () => ({
-    te: (t) => t,
+    te: () => true,
+    t: (t) => t,
   }),
 }))
 
 jest.mock("src/use/forms", () => ({
+  ...jest.requireActual("src/use/forms"),
   useDirtyGuard: () => {},
   useFormState: () => ({
     dirty: mockRef(false),
@@ -103,7 +105,7 @@ describe("VQInput", () => {
 
     expect(wrapper.findComponent({ name: "q-input" }).exists()).toBe(true)
 
-    wrapper.vm.parentState = "loading"
+    wrapper.vm.formState = "loading"
     await nextTick()
 
     expect(wrapper.findComponent({ name: "q-input" }).exists()).toBe(false)

--- a/client/src/components/forms/AccountProfileForm.jest.spec.js
+++ b/client/src/components/forms/AccountProfileForm.jest.spec.js
@@ -1,0 +1,59 @@
+import AccountProfileForm from "./AccountProfileForm.vue"
+import { mount } from "@vue/test-utils"
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest"
+import { ref as mockRef } from "vue"
+import { useFormState } from "src/use/forms"
+
+jest.mock("src/use/forms", () => ({
+  ...jest.requireActual("src/use/forms"),
+  useDirtyGuard: () => {},
+  useFormState: () => ({
+    dirty: mockRef(false),
+    saved: mockRef(false),
+    state: mockRef("idle"),
+    queryLoading: mockRef(false),
+    mutationLoading: mockRef(false),
+    errorMessage: mockRef(""),
+  }),
+}))
+
+installQuasarPlugin()
+describe("AccountProfileForm", () => {
+  const makeWrapper = () => {
+    return mount(AccountProfileForm, {
+      global: {
+        mocks: {
+          $t: (t) => t,
+        },
+        provide: {
+          formState: useFormState(),
+        },
+      },
+      props: {
+        accountProfile: {},
+      },
+    })
+  }
+
+  test("able to save", async () => {
+    const wrapper = makeWrapper()
+    expect(wrapper).toBeTruthy()
+    //Validation rules are tested as part userValidation, we only need to confirm that password can be empty.
+
+    wrapper
+      .findComponent({ ref: "usernameInput" })
+      .findComponent({ name: "q-input" })
+      .setValue("testuser")
+    wrapper
+      .findComponent({ ref: "nameInput" })
+      .findComponent({ name: "q-input" })
+      .setValue("Test User")
+    wrapper
+      .findComponent({ ref: "emailInput" })
+      .findComponent({ name: "q-input" })
+      .setValue("testemail@example.com")
+
+    await wrapper.findComponent({ name: "q-form" }).trigger("submit")
+    expect(wrapper.emitted("save")).toHaveLength(1)
+  })
+})

--- a/client/src/components/forms/AccountProfileForm.vue
+++ b/client/src/components/forms/AccountProfileForm.vue
@@ -4,13 +4,13 @@
     <v-q-wrap t-prefix="account.account.fields" @vqupdate="updateVQ">
       <form-section first-section>
         <template #header>Account Information</template>
-        <v-q-input ref="nameInput" :v="v$.name" data-cy="update_user_name" />
-        <v-q-input ref="emailInput" :v="v$.email" data-cy="update_user_email" />
         <v-q-input
           ref="usernameInput"
           :v="v$.username"
           data-cy="update_user_username"
         />
+        <v-q-input ref="nameInput" :v="v$.name" data-cy="update_user_name" />
+        <v-q-input ref="emailInput" :v="v$.email" data-cy="update_user_email" />
       </form-section>
       <form-section>
         <template #header>Update Password</template>
@@ -31,7 +31,7 @@ import FormSection from "src/components/molecules/FormSection.vue"
 import FormActions from "src/components/molecules/FormActions.vue"
 import VQInput from "src/components/atoms/VQInput.vue"
 import VQWrap from "src/components/atoms/VQWrap.vue"
-import VNewPasswordInput from "../VNewPasswordInput.vue"
+import VNewPasswordInput from "./VNewPasswordInput.vue"
 import { useVuelidate } from "@vuelidate/core"
 import { reactive, watchEffect, inject, computed } from "vue"
 import { isEqual, pick } from "lodash"
@@ -62,7 +62,7 @@ delete rules.password.required
 
 const v$ = useVuelidate(rules, form)
 
-const { dirty } = inject("formState")
+const { dirty, errorMessage } = inject("formState")
 
 watchEffect(() => {
   dirty.value = !isEqual(original.value, form)
@@ -81,6 +81,11 @@ function onRevert() {
   Object.assign(form, original.value)
 }
 function onSubmit() {
-  emit("save", form)
+  v$.value.$touch()
+  if (v$.value.$invalid) {
+    errorMessage.value = "Oops, check form about for errors."
+  } else {
+    emit("save", form)
+  }
 }
 </script>

--- a/client/src/components/forms/AccountProfileForm.vue
+++ b/client/src/components/forms/AccountProfileForm.vue
@@ -1,4 +1,3 @@
-+
 <template>
   <q-form data-cy="vueAccount" @submit="onSubmit">
     <v-q-wrap t-prefix="account.account.fields" @vqupdate="updateVQ">

--- a/client/src/components/forms/NewPasswordInput.vue
+++ b/client/src/components/forms/NewPasswordInput.vue
@@ -12,7 +12,7 @@
         <slot :name="name" v-bind="{ ...slotData }" />
       </template>
     </password-input>
-    <div class="row items-center" style="max-width: 400px">
+    <div class="row items-center">
       <new-password-input-meter
         :max="4"
         :score="score"

--- a/client/src/components/forms/NewPasswordInput.vue
+++ b/client/src/components/forms/NewPasswordInput.vue
@@ -5,45 +5,45 @@
       :model-value="$props.modelValue"
       :label="label"
       autocomplete="new-password"
-      bottom-slots
       :error="error"
       @update:model-value="$emit('update:modelValue', $event)"
     >
-      <template #counter>
-        <q-chip
-          icon="help"
-          dense
-          size="sm"
-          clickable
-          :aria-label="$t('auth.aria.more_info_password')"
-          aria-controls="password-field-analysis"
-          :aria-expanded="showDetails.toString()"
-          tabindex="0"
-          role="button"
-          outline
-          @click="showDetails = !showDetails"
-          @keydown.enter.space="showDetails = !showDetails"
-        >
-          {{ $t("buttons.more_info") }}
-        </q-chip>
-      </template>
-      <template #hint>
-        <new-password-input-meter :max="4" :score="score" :valid="!error" />
-        <div v-if="$props.modelValue.length > 0" class="password-summary">
-          <span v-if="!error">{{
-            $t("auth.validation.PASSWORD_COMPLEX")
-          }}</span>
-          <span v-else>{{ $t("auth.validation.PASSWORD_NOT_COMPLEX") }}</span>
-        </div>
-        <div
-          v-else-if="$props.modelValue.length == 0 && error"
-          v-text="$t('helpers.REQUIRED_FIELD', [[$t('auth.fields.password')]])"
-        />
-      </template>
       <template v-for="(_, name) in $slots" #[name]="slotData">
         <slot :name="name" v-bind="{ ...slotData }" />
       </template>
     </password-input>
+    <div class="row items-center" style="max-width: 400px">
+      <new-password-input-meter
+        :max="4"
+        :score="score"
+        :valid="!error"
+        class="col"
+      />
+      <q-chip
+        icon="help"
+        dense
+        size="sm"
+        clickable
+        :aria-label="$t('auth.aria.more_info_password')"
+        aria-controls="password-field-analysis"
+        :aria-expanded="showDetails.toString()"
+        tabindex="0"
+        role="button"
+        outline
+        class="col-3"
+        @click="showDetails = !showDetails"
+        @keydown.enter.space="showDetails = !showDetails"
+      >
+        {{ $t("buttons.more_info") }}
+      </q-chip>
+    </div>
+    <div v-if="$props.modelValue.length > 0" class="password-summary">
+      <span v-if="!error">{{ $t("auth.validation.PASSWORD_COMPLEX") }}</span>
+    </div>
+    <div
+      v-else-if="$props.modelValue.length == 0 && error"
+      v-text="$t('helpers.REQUIRED_FIELD', [[$t('auth.fields.password')]])"
+    />
     <div
       v-if="showDetails"
       id="password-field-analysis"

--- a/client/src/components/forms/ProfileMetadataForm.jest.spec.js
+++ b/client/src/components/forms/ProfileMetadataForm.jest.spec.js
@@ -6,6 +6,7 @@ import flushPromises from "flush-promises"
 import { ref as mockRef } from "vue"
 
 jest.mock("src/use/forms", () => ({
+  ...jest.requireActual("src/use/forms"),
   useDirtyGuard: () => {},
   useFormState: () => ({
     dirty: mockRef(false),

--- a/client/src/components/forms/ProfileMetadataForm.vue
+++ b/client/src/components/forms/ProfileMetadataForm.vue
@@ -214,7 +214,8 @@ import { mapObject } from "src/utils/objUtils"
 const props = defineProps({
   profileMetadata: {
     required: true,
-    validator: (v) => v === null || typeof v === "object",
+    validator: (v) =>
+      v === null || typeof v === "object" || typeof v === "undefined",
   },
 })
 

--- a/client/src/components/forms/VNewPasswordInput.vue
+++ b/client/src/components/forms/VNewPasswordInput.vue
@@ -1,0 +1,117 @@
+<template>
+  <div>
+    <password-input
+      v-model="model"
+      v-bind="{ ...$attrs }"
+      outlined
+      :label="$t(getTranslationKey('label'))"
+      :hint="$t(getTranslationKey('hint'))"
+      autocomplete="new-password"
+      :error="v.$error"
+    >
+      <template v-if="!$slots.error" #error>
+        <error-field-renderer
+          :errors="v.$errors"
+          :prefix="$t(getTranslationKey('errors'))"
+        />
+      </template>
+      <template #counter>
+        <q-chip
+          icon="help"
+          dense
+          size="sm"
+          clickable
+          :aria-label="$t('auth.aria.more_info_password')"
+          aria-controls="password-field-analysis"
+          :aria-expanded="showDetails.toString()"
+          tabindex="0"
+          role="button"
+          outline
+          class="col-3"
+          @click="showDetails = !showDetails"
+          @keydown.enter.space="showDetails = !showDetails"
+        >
+          {{ $t("buttons.more_info") }}
+        </q-chip>
+      </template>
+      <template v-for="(_, name) in $slots" #[name]="slotData">
+        <slot :name="name" v-bind="{ ...slotData }" />
+      </template>
+    </password-input>
+    <div class="row items-center" style="max-width: 400px">
+      <new-password-input-meter
+        :max="4"
+        :score="score"
+        :valid="!v.$error"
+        class="col"
+      />
+    </div>
+    <div
+      v-if="showDetails && model.length"
+      id="password-field-analysis"
+      class="password-details alert alert-tip"
+    >
+      <div class="alert-title">
+        {{ $t("auth.password_meter.header") }}
+      </div>
+      <new-password-input-analysis
+        :complexity="complexity"
+        class="alert-body"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from "vue"
+export default defineComponent({
+  inheritAttrs: false,
+})
+</script>
+
+<script setup>
+import NewPasswordInputAnalysis from "./atoms/NewPasswordInputAnalysis.vue"
+import PasswordInput from "./PasswordInput.vue"
+import NewPasswordInputMeter from "./atoms/NewPasswordInputMeter.vue"
+import ErrorFieldRenderer from "src/components/molecules/ErrorFieldRenderer.vue"
+import { computed, ref } from "vue"
+import { useVQWrap } from "src/use/forms"
+
+const props = defineProps({
+  v: {
+    type: Object,
+    required: true,
+  },
+  t: {
+    type: [String, Boolean],
+    default: false,
+  },
+})
+
+defineEmits(["vqupdate"])
+
+const { getTranslationKey, model } = useVQWrap(props.v, props.t)
+const showDetails = ref(false)
+
+const complexity = computed(() => {
+  return props.v.notComplex.$response.complexity
+})
+
+const score = computed(() => {
+  return complexity.value.score
+})
+</script>
+
+<style lang="sass" scoped>
+.q-field--with-bottom
+  padding-bottom: 40px
+
+.password-details
+  font-size: 12px
+
+.q-chip
+  margin: 0
+
+.password-warning
+  font-weight: bold
+</style>

--- a/client/src/components/forms/atoms/AccountProfileForm.vue
+++ b/client/src/components/forms/atoms/AccountProfileForm.vue
@@ -1,0 +1,98 @@
+<template>
+  <q-form data-cy="vueAccount" @submit="onSubmit">
+    <v-q-wrap t-prefix="account.account.fields" @vqupdate="updateVQ">
+      <form-section first-section>
+        <template #header>Account Information</template>
+        <v-q-input ref="nameInput" :v="v$.name" data-cy="update_user_name" />
+        <v-q-input ref="emailInput" :v="v$.email" data-cy="update_user_email" />
+        <v-q-input
+          ref="usernameInput"
+          :v="v$.username"
+          data-cy="update_user_username"
+        />
+      </form-section>
+      <form-section>
+        <template #header>Update Password</template>
+        <NewPasswordInput
+          ref="passwordInput"
+          v-model="v$.password.$model"
+          outlined
+          data-cy="update_user_password"
+          :complexity="v$.password.notComplex.$response.complexity"
+          :error="v$.password.$error"
+          label="Password"
+        >
+          <template #append>
+            <q-icon class="cursor-pointer" />
+          </template>
+          <template #error>
+            <error-field-renderer
+              :errors="v$.password.$errors"
+              prefix="auth.validation.password"
+            />
+          </template>
+        </NewPasswordInput>
+      </form-section>
+      <form-actions @reset-click="onRevert" />
+    </v-q-wrap>
+  </q-form>
+</template>
+
+<script setup>
+import ErrorFieldRenderer from "src/components/molecules/ErrorFieldRenderer.vue"
+import FormSection from "src/components/molecules/FormSection.vue"
+import FormActions from "src/components/molecules/FormActions.vue"
+import VQInput from "src/components/atoms/VQInput.vue"
+import VQWrap from "src/components/atoms/VQWrap.vue"
+import NewPasswordInput from "../NewPasswordInput.vue"
+import { useVuelidate } from "@vuelidate/core"
+import { reactive, watchEffect, inject, computed } from "vue"
+import { isEqual, pick } from "lodash"
+import { rules } from "src/use/userValidation"
+const props = defineProps({
+  accountProfile: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(["save"])
+
+const original = computed(() => ({
+  password: "",
+  ...pick(props.accountProfile, ["username", "name", "email"]),
+}))
+
+const form = reactive({
+  username: "",
+  password: "",
+  email: "",
+  name: "",
+})
+
+delete rules.password.required
+
+const v$ = useVuelidate(rules, form)
+
+const { dirty } = inject("formState")
+
+watchEffect(() => {
+  dirty.value = !isEqual(original.value, form)
+})
+
+watchEffect(() => {
+  if (!props.accountProfile) return
+  Object.assign(form, original.value)
+})
+
+function updateVQ(validator, newValue) {
+  validator.$model = newValue
+}
+
+function onRevert() {
+  Object.assign(form, original.value)
+}
+function onSubmit() {
+  emit("save", form)
+}
+</script>

--- a/client/src/components/forms/atoms/AccountProfileForm.vue
+++ b/client/src/components/forms/atoms/AccountProfileForm.vue
@@ -1,3 +1,4 @@
++
 <template>
   <q-form data-cy="vueAccount" @submit="onSubmit">
     <v-q-wrap t-prefix="account.account.fields" @vqupdate="updateVQ">
@@ -13,25 +14,12 @@
       </form-section>
       <form-section>
         <template #header>Update Password</template>
-        <NewPasswordInput
+        <VNewPasswordInput
           ref="passwordInput"
-          v-model="v$.password.$model"
-          outlined
           data-cy="update_user_password"
-          :complexity="v$.password.notComplex.$response.complexity"
-          :error="v$.password.$error"
-          label="Password"
+          :v="v$.password"
         >
-          <template #append>
-            <q-icon class="cursor-pointer" />
-          </template>
-          <template #error>
-            <error-field-renderer
-              :errors="v$.password.$errors"
-              prefix="auth.validation.password"
-            />
-          </template>
-        </NewPasswordInput>
+        </VNewPasswordInput>
       </form-section>
       <form-actions @reset-click="onRevert" />
     </v-q-wrap>
@@ -39,12 +27,11 @@
 </template>
 
 <script setup>
-import ErrorFieldRenderer from "src/components/molecules/ErrorFieldRenderer.vue"
 import FormSection from "src/components/molecules/FormSection.vue"
 import FormActions from "src/components/molecules/FormActions.vue"
 import VQInput from "src/components/atoms/VQInput.vue"
 import VQWrap from "src/components/atoms/VQWrap.vue"
-import NewPasswordInput from "../NewPasswordInput.vue"
+import VNewPasswordInput from "../VNewPasswordInput.vue"
 import { useVuelidate } from "@vuelidate/core"
 import { reactive, watchEffect, inject, computed } from "vue"
 import { isEqual, pick } from "lodash"

--- a/client/src/components/forms/atoms/AccountProfileForm.vue
+++ b/client/src/components/forms/atoms/AccountProfileForm.vue
@@ -38,8 +38,9 @@ import { isEqual, pick } from "lodash"
 import { rules } from "src/use/userValidation"
 const props = defineProps({
   accountProfile: {
-    type: Object,
     required: true,
+    validator: (v) =>
+      v === null || typeof v === "object" || typeof v === "undefined",
   },
 })
 

--- a/client/src/components/forms/atoms/NewPasswordInputMeter.vue
+++ b/client/src/components/forms/atoms/NewPasswordInputMeter.vue
@@ -4,7 +4,7 @@
     :class="valid ? 'password-success' : 'password-error'"
   >
     <div
-      v-for="(item, index) in new Array(max)"
+      v-for="(_, index) in new Array(max)"
       :key="index"
       :class="score > index ? 'active' : ''"
       class="col"

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -151,7 +151,7 @@ export default {
         },
         name: {
           label: "Name",
-          hint: "How you would like your name represented on the site.  Include any honorific, etc that you would like to use.",
+          hint: "(Optional) Your name will often substitute appearances of your username on this site.  Honorifics accepted.",
           errors: {
             maxLength: "@:generic_validation.maxLength",
           },

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -144,7 +144,7 @@ export default {
       fields: {
         username: {
           label: "Username",
-          hint: "Your username is your identify on this site.",
+          hint: "Your username is your primary identity on this site.",
           errors: {
             maxLength: "@:generic_validations.maxLength",
           },

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -158,7 +158,7 @@ export default {
         },
         email: {
           label: "Email Address",
-          hint: "Note updating your email address will require you to re-validate your account.",
+          hint: "Updating your email address will require you to re-verify your account.",
           errors: {
             maxLength: "@:generic_validations.maxLength",
             email: "Please enter a valid email address.",

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -147,6 +147,7 @@ export default {
           hint: "Your username is your primary identity on this site.",
           errors: {
             maxLength: "@:generic_validations.maxLength",
+            USERNAME_IN_USE: "Sorry, this username is already in use.",
           },
         },
         name: {

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -140,6 +140,40 @@ export default {
       affiliations: "Affiliations",
       privacy: "Privacy",
     },
+    account: {
+      fields: {
+        username: {
+          label: "Username",
+          hint: "Your username is your identify on this site.",
+          errors: {
+            maxLength: "@:generic_validations.maxLength",
+          },
+        },
+        name: {
+          label: "Name",
+          hint: "How you would like your name represented on the site.  Include any honorific, etc that you would like to use.",
+          errors: {
+            maxLength: "@:generic_validation.maxLength",
+          },
+        },
+        email: {
+          label: "Email Address",
+          hint: "Note updating your email address will require you to re-validate your account.",
+          errors: {
+            maxLength: "@:generic_validations.maxLength",
+            email: "Please enter a valid email address.",
+          },
+        },
+        password: {
+          label: "New Password",
+          hint: "Enter a new password here. (Leave blank to keep your current password)",
+          errors: {
+            notComplex:
+              "Your password is not complex enough.  Click (More Info) for suggestions.",
+          },
+        },
+      },
+    },
     profile: {
       section_details: "Profile Details",
       section_personal: "Personal Details",

--- a/client/src/pages/Account/MetadataPage.jest.spec.js
+++ b/client/src/pages/Account/MetadataPage.jest.spec.js
@@ -9,6 +9,7 @@ import { UPDATE_PROFILE_METADATA } from "src/graphql/mutations"
 import flushPromises from "flush-promises"
 
 jest.mock("src/use/forms", () => ({
+  ...jest.requireActual("src/use/forms"),
   useDirtyGuard: () => {},
   useFormState: () => ({
     dirty: mockRef(false),
@@ -32,6 +33,7 @@ describe("MetadataPage", () => {
         mocks: {
           $t: (t) => t,
         },
+        stubs: ["profile-metadata-form"],
       },
     })
     await flushPromises()

--- a/client/src/pages/Account/ProfilePage.vue
+++ b/client/src/pages/Account/ProfilePage.vue
@@ -16,7 +16,7 @@ import { useMutation } from "@vue/apollo-composable"
 import { useI18n } from "vue-i18n"
 import { useFormState, useDirtyGuard } from "src/use/forms"
 import { provide } from "vue"
-import AccountProfileForm from "src/components/forms/atoms/AccountProfileForm.vue"
+import AccountProfileForm from "src/components/forms/AccountProfileForm.vue"
 const importValidationErrors = function (error, vm) {
   const gqlErrors = error?.graphQLErrors ?? []
   var hasVErrors = false

--- a/client/src/pages/Account/ProfilePage.vue
+++ b/client/src/pages/Account/ProfilePage.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <account-profile-form :account-profile="currentUser" @save="updateUser" />
+    <account-profile-form
+      ref="form"
+      :account-profile="currentUser"
+      @save="updateUser"
+    />
   </div>
 </template>
 

--- a/client/src/pages/Account/ProfilePage.vue
+++ b/client/src/pages/Account/ProfilePage.vue
@@ -53,7 +53,7 @@ const { t } = useI18n()
 async function updateUser(newValues) {
   errorMessage.value = ""
   saved.value = false
-  const vars = { ...newValues }
+  const vars = { id: currentUser.value.id, ...newValues }
 
   if ((vars?.password?.length ?? 0) === 0) {
     delete vars.password

--- a/client/src/use/forms.jest.spec.js
+++ b/client/src/use/forms.jest.spec.js
@@ -1,0 +1,201 @@
+import { mount } from "vue-composable-tester"
+import { useDirtyGuard, useFormState, useVQWrap } from "./forms"
+import { provide, ref } from "vue"
+
+let dirtyGuardCallback = null
+
+jest.mock("vue-router", () => ({
+  onBeforeRouteLeave: jest.fn((cb) => {
+    dirtyGuardCallback = cb
+  }),
+}))
+
+const mockEmit = jest.fn()
+
+jest.mock("vue", () => ({
+  ...jest.requireActual("vue"),
+  getCurrentInstance: () => ({
+    emit: mockEmit,
+  }),
+}))
+
+const mockDialog = jest.fn()
+jest.mock("quasar", () => ({
+  ...jest.requireActual("quasar"),
+  useQuasar: () => ({
+    dialog: mockDialog,
+  }),
+}))
+
+describe("useDirtyGuard composable", () => {
+  test("allows a clean navigation to continue", () => {
+    const dirty = ref(false)
+
+    mount(() => useDirtyGuard(dirty))
+
+    const mockNext = jest.fn()
+    dirtyGuardCallback(null, null, mockNext)
+    expect(mockNext).toHaveBeenCalledTimes(1)
+    expect(mockNext).toHaveBeenCalledWith()
+  })
+
+  test("Shows dialog appropriatly and correctly responds to user feedback", () => {
+    const dirty = ref(true)
+    let okCallback, cancelCallback
+    const dialogReturn = {
+      onOk: (okCb) => {
+        okCallback = okCb
+        return dialogReturn
+      },
+      onCancel: (cancelCb) => {
+        cancelCallback = cancelCb
+        return dialogReturn
+      },
+    }
+    mockDialog.mockImplementation(() => dialogReturn)
+
+    mount(() => useDirtyGuard(dirty))
+    const mockNext = jest.fn()
+    dirtyGuardCallback(null, null, mockNext)
+
+    expect(mockDialog).toBeCalledTimes(1)
+    okCallback()
+    expect(mockNext).toHaveBeenCalledTimes(1)
+    expect(mockNext).toHaveBeenCalledWith()
+
+    mockNext.mockReset()
+
+    cancelCallback()
+    expect(mockNext).toHaveBeenCalledTimes(1)
+    expect(mockNext).toHaveBeenCalledWith(false)
+
+    mockNext.mockReset()
+    dirty.value = false
+    dirtyGuardCallback(null, null, mockNext)
+    expect(mockNext).toHaveBeenCalledTimes(1)
+    expect(mockNext).toBeCalledWith()
+  })
+
+  test("sets and removes window handlers", () => {
+    let callBackFn
+    const dirty = ref(false)
+    window.addEventListener = jest.fn((_, callback) => {
+      callBackFn = callback
+    })
+    window.removeEventListener = jest.fn()
+    const mockEvent = {
+      preventDefault: jest.fn(),
+    }
+
+    const { unmount } = mount(() => useDirtyGuard(dirty))
+
+    //should add an eventlistener
+    expect(window.addEventListener).toHaveBeenCalledTimes(1)
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    )
+
+    //Test event callback if not dirty
+    callBackFn(mockEvent)
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(0)
+
+    //Test event callback if is dirty
+    dirty.value = true
+    callBackFn(mockEvent)
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1)
+
+    //Check that event listeners are removed on unmount
+    unmount()
+    expect(window.removeEventListener).toHaveBeenCalledTimes(1)
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      "beforeunload",
+      callBackFn
+    )
+  })
+})
+
+describe("useFormState composable", () => {
+  test("form states", () => {
+    const queryLoading = ref(false),
+      mutationLoading = ref(false)
+    const { result } = mount(() => useFormState(queryLoading, mutationLoading))
+    const { state, saved, dirty, errorMessage } = result
+
+    expect(state.value).toBe("idle")
+    queryLoading.value = true
+
+    expect(state.value).toBe("loading")
+
+    mutationLoading.value = true
+    expect(state.value).toBe("saving")
+
+    saved.value = true
+    expect(state.value).toBe("saving")
+
+    mutationLoading.value = false
+    queryLoading.value = false
+    expect(state.value).toBe("saved")
+
+    saved.value = false
+    dirty.value = true
+    expect(state.value).toBe("dirty")
+
+    dirty.value = false
+    errorMessage.value = "error message"
+    expect(state.value).toBe("error")
+  })
+})
+
+describe("useVQWrap composable", () => {
+  const validator = {
+    $model: "",
+    $path: "testField",
+  }
+  test("without vqwrap provides present", () => {
+    const { result } = mount(() => useVQWrap(validator, false))
+
+    const { getTranslationKey, model } = result
+
+    expect(getTranslationKey("label")).toBe("testField.label")
+
+    model.value = "new Value"
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith("vqupdate", validator, "new Value")
+  })
+
+  test("update function provider", () => {
+    const mockUpdate = jest.fn()
+    const { result } = mount(() => useVQWrap(validator, false), {
+      provider: () => {
+        provide("vqupdate", mockUpdate)
+      },
+    })
+    const { model } = result
+
+    model.value = "parent update"
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith(validator, "parent update")
+  })
+  test("provided prefix is used", () => {
+    const { result } = mount(() => useVQWrap(validator, false), {
+      provider: () => {
+        provide("tPrefix", "parentPrefix")
+      },
+    })
+    const { getTranslation } = result
+
+    expect(getTranslation("error")).toBe("parentPrefix.testField.error")
+  })
+
+  test("local translation path overrides prefix", () => {
+    const { result } = mount(() => useVQWrap(validator, "localPath"), {
+      provider: () => {
+        provide("tPrefix", "parentPrefix")
+      },
+    })
+    const { getTranslation } = result
+
+    expect(getTranslation("error")).toBe("localPath.error")
+  })
+})

--- a/client/src/use/forms.js
+++ b/client/src/use/forms.js
@@ -1,7 +1,15 @@
 import DiscardChangesDialog from "src/components/dialogs/DiscardChangesDialog.vue"
-import { computed, onMounted, onUnmounted, ref } from "vue"
+import {
+  computed,
+  onMounted,
+  onUnmounted,
+  ref,
+  getCurrentInstance,
+  inject,
+} from "vue"
 import { onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
+import { useI18n } from "vue-i18n"
 
 export function useDirtyGuard(dirtyRef) {
   const { dialog } = useQuasar()
@@ -69,4 +77,50 @@ export function useFormState(queryLoadingRef, mutationLoadingRef) {
     mutationLoading: mutationLoadingRef,
     errorMessage,
   }
+}
+
+export function useVQWrap(validator, tPath) {
+  const { emit } = getCurrentInstance()
+
+  const { te, t } = useI18n()
+  const parentUpdate = inject("vqupdate", null)
+
+  const parentTPrefix = inject("tPrefix", "")
+
+  const tPrefix = computed(() => {
+    if (typeof tPath === "string") {
+      return tPath
+    }
+    const prefix = parentTPrefix ? `${parentTPrefix}.` : ""
+    return `${prefix}${validator.$path}`
+  })
+
+  function getTranslationKey(key) {
+    return `${tPrefix.value}.${key}`
+  }
+
+  function getTranslation(key) {
+    if (!te(getTranslationKey(key))) return ""
+    return t(getTranslationKey(key))
+  }
+
+  function updateValue(newValue) {
+    if (parentUpdate) {
+      parentUpdate(validator, newValue)
+    } else {
+      emit("vqupdate", validator, newValue)
+    }
+  }
+
+  const model = computed({
+    get() {
+      return validator.$model
+    },
+    set(newValue) {
+      const value = newValue !== null ? newValue : ""
+      updateValue(value)
+    },
+  })
+
+  return { getTranslationKey, getTranslation, model }
 }

--- a/client/src/use/forms.js
+++ b/client/src/use/forms.js
@@ -10,6 +10,8 @@ import {
 import { onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
 import { useI18n } from "vue-i18n"
+import { isEmpty } from "lodash"
+import { unflatten } from "flat"
 
 export function useDirtyGuard(dirtyRef) {
   const { dialog } = useQuasar()
@@ -123,4 +125,26 @@ export function useVQWrap(validator, tPath) {
   })
 
   return { getTranslationKey, getTranslation, model }
+}
+
+export function useGraphQLValidation(errorRef) {
+  const validationErrors = computed(() => {
+    const gqlErrors = errorRef.value?.graphQLErrors ?? []
+    const serverValidationErrors = {}
+    gqlErrors.forEach((item) => {
+      const vErrors = item?.extensions?.validation ?? false
+      if (vErrors !== false) {
+        for (const [fieldName, fieldErrors] of Object.entries(vErrors)) {
+          serverValidationErrors[fieldName] = fieldErrors
+        }
+      }
+    })
+    return unflatten(serverValidationErrors)
+  })
+
+  const hasValidationErrors = computed(() => {
+    return !isEmpty(validationErrors.value)
+  })
+
+  return { validationErrors, hasValidationErrors }
 }

--- a/client/src/use/userValidation.jest.spec.js
+++ b/client/src/use/userValidation.jest.spec.js
@@ -59,7 +59,7 @@ describe("test uservalidation composable", () => {
     user.password = ""
     eV.$touch()
     expect(eV.required.$invalid).toBeTruthy()
-    expect(eV.notComplex.$invalid).toBeTruthy()
+    expect(eV.notComplex.$invalid).not.toBeTruthy()
 
     user.password = "password"
     eV.$touch()

--- a/client/src/use/userValidation.js
+++ b/client/src/use/userValidation.js
@@ -1,6 +1,6 @@
 import { reactive } from "vue"
 import useVuelidate from "@vuelidate/core"
-import { required, email } from "@vuelidate/validators"
+import { required, email, helpers } from "@vuelidate/validators"
 import { CREATE_USER } from "src/graphql/mutations"
 import { useMutation } from "@vue/apollo-composable"
 import zxcvbn from "zxcvbn"
@@ -21,7 +21,7 @@ export const rules = {
       const complexity = zxcvbn(value)
       return {
         complexity,
-        $valid: complexity.score >= 3,
+        $valid: !helpers.req(value) || complexity.score >= 3,
       }
     },
   },

--- a/client/src/use/userValidation.js
+++ b/client/src/use/userValidation.js
@@ -6,6 +6,27 @@ import { useMutation } from "@vue/apollo-composable"
 import zxcvbn from "zxcvbn"
 import { applyExternalValidationErrors } from "src/use/validationHelpers"
 
+export const rules = {
+  name: {},
+  email: {
+    required,
+    email,
+  },
+  username: {
+    required,
+  },
+  password: {
+    required,
+    notComplex(value) {
+      const complexity = zxcvbn(value)
+      return {
+        complexity,
+        $valid: complexity.score >= 3,
+      }
+    },
+  },
+}
+
 export function useUserValidation() {
   const form = reactive({
     email: "",
@@ -20,27 +41,6 @@ export function useUserValidation() {
     name: [],
     username: [],
   })
-
-  const rules = {
-    name: {},
-    email: {
-      required,
-      email,
-    },
-    username: {
-      required,
-    },
-    password: {
-      required,
-      notComplex(value) {
-        const complexity = zxcvbn(value)
-        return {
-          complexity,
-          $valid: complexity.score >= 3,
-        }
-      },
-    },
-  }
 
   const $v = useVuelidate(rules, form, { $externalResults: externalValidation })
 


### PR DESCRIPTION
This PR: 
* Adds a VQwrap form composable for validator are input reuse
* Adds VNewPasswordInput which is validator aware
* Factors out account profile form to its own page
* Uses userValidation composable to validation profile edit fields.