### PR TITLE
refactor: Replace string IDs with constants

### DIFF
--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 
 use App\Events\SubmissionCreated;
 use App\Listeners\NotifyUsersAboutCreatedSubmission;
+use App\Models\Role;
 use App\Models\Submission;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -26,13 +27,13 @@ class SubmissionSeeder extends Seeder
             ->hasAttached(
                 User::where('username', 'regularUser')->firstOrFail(),
                 [
-                    'role_id' => 6,
+                    'role_id' => Role::SUBMITTER_ROLE_ID,
                 ]
             )
             ->hasAttached(
                 User::where('username', 'reviewCoordinator')->firstOrFail(),
                 [
-                    'role_id' => 4,
+                    'role_id' => Role::REVIEW_COORDINATOR_ROLE_ID,
                 ]
             )
             ->create([

--- a/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
+++ b/backend/tests/Feature/Notifications/SubmissionCreatedTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Notifications;
 use App\Events\SubmissionCreated;
 use App\Listeners\NotifyUsersAboutCreatedSubmission;
 use App\Models\Publication;
+use App\Models\Role;
 use App\Models\Submission;
 use App\Models\User;
 use App\Notifications\SubmissionCreated as NotificationsSubmissionCreated;
@@ -29,7 +30,7 @@ class SubmissionCreatedTest extends TestCase
             ->hasAttached(
                 $editor,
                 [
-                    'role_id' => 3,
+                    'role_id' => Role::EDITOR_ROLE_ID,
                 ]
             )
             ->create();
@@ -37,7 +38,7 @@ class SubmissionCreatedTest extends TestCase
             ->hasAttached(
                 $submitter,
                 [
-                    'role_id' => 6,
+                    'role_id' => Role::SUBMITTER_ROLE_ID,
                 ]
             )
             ->create([


### PR DESCRIPTION
This PR replaces hardcoded references to role IDs with constants as defined in `/backend/app/Models/Role.php`. 

Remarkably, there weren't nearly as many hardcoded references in `/backend` as I previously believed there were. 

Closes #643 