### PR TITLE
refactor: Use Tiptap to Display Submission Text

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@apollo/client": "^3.5.10",
     "@quasar/extras": "^1.13.5",
     "@tiptap/extension-bold": "^2.0.0-beta.26",
+    "@tiptap/extension-highlight": "^2.0.0-beta.33",
     "@tiptap/extension-italic": "^2.0.0-beta.26",
     "@tiptap/extension-link": "^2.0.0-beta.36",
     "@tiptap/extension-ordered-list": "^2.0.0-beta.27",

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -43,6 +43,7 @@
 <script setup>
 import { ref } from "vue"
 import { Editor, EditorContent } from "@tiptap/vue-3"
+import Highlight from "@tiptap/extension-highlight"
 import StarterKit from "@tiptap/starter-kit"
 
 let darkMode = ref(true)
@@ -63,11 +64,9 @@ const editor = new Editor({
       justo donec enim diam vulputate ut. Eget lorem dolor sed viverra ipsum
       nunc. Ut tortor pretium viverra suspendisse potenti nullam ac tortor
       vitae.
-      <span class="highlight"
-        >Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Et
+      <mark>Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Et
         egestas quis ipsum suspendisse ultrices gravida. In est ante in nibh
-        mauris cursus mattis.</span
-      >
+        mauris cursus mattis.</mark>
       Amet purus gravida quis blandit turpis cursus. Auctor neque vitae tempus
       quam pellentesque nec nam aliquam sem. At consectetur lorem donec massa
       sapien faucibus. Et ultrices neque ornare aenean. Hac habitasse platea
@@ -107,11 +106,9 @@ const editor = new Editor({
       rhoncus dolor purus non enim. In nisl nisi scelerisque eu ultrices. Tempor
       commodo ullamcorper a lacus vestibulum. Nisl nisi scelerisque eu ultrices
       vitae auctor eu. Urna id volutpat
-      <span class="highlight"
-        >lacus laoreet non curabitur. Dolor magna eget est lorem ipsum dolor.
+      <mark>lacus laoreet non curabitur. Dolor magna eget est lorem ipsum dolor.
         Mauris vitae ultricies leo integer malesuada nunc vel risus
-        commodo.</span
-      >
+        commodo.</mark>
     </p>
     <h3>Commodo quis</h3>
     <p>
@@ -142,37 +139,41 @@ const editor = new Editor({
       pellentesque.
     </p>
       `,
-  extensions: [StarterKit],
+  extensions: [StarterKit, Highlight],
 })
 </script>
 
-<style lang="sass" scoped>
-.submission-content
-  counter-reset: paragraph_counter
-  font-size: 16px
-  margin: 0 auto
-  max-width: 700px
-  padding: 10px 60px 60px
+<style lang="scss">
+.submission-content {
+  counter-reset: paragraph_counter;
+  font-size: 16px;
+  margin: 0 auto;
+  max-width: 700px;
+  padding: 10px 60px 60px;
+}
 
-.submission-content p
-  position: relative
+.submission-content p {
+  position: relative;
+}
 
-.submission-content p:before
-  color: #555
-  content: "¶ " counter(paragraph_counter)
-  counter-increment: paragraph_counter
-  display: block
-  font-family: Helvetica, Arial, san-serif
-  font-size: 1em
-  margin-right: 10px
-  min-width: 50px
-  position: absolute
-  right: 100%
-  text-align: right
-  top: 0
-  white-space: nowrap
+.submission-content p:before {
+  color: #555;
+  content: "¶ " counter(paragraph_counter);
+  counter-increment: paragraph_counter;
+  display: block;
+  font-family: Helvetica, Arial, san-serif;
+  font-size: 1em;
+  margin-right: 10px;
+  min-width: 50px;
+  position: absolute;
+  right: 100%;
+  text-align: right;
+  top: 0;
+  white-space: nowrap;
+}
 
-.highlight
-  color: #000
-  background-color: #bbe2e8
+mark {
+  color: #000;
+  background-color: #bbe2e8;
+}
 </style>

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -37,6 +37,24 @@
     </div>
   </div>
   <article class="col-sm-9 submission-content">
+    <editor-content :editor="editor" />
+  </article>
+</template>
+<script setup>
+import { ref } from "vue"
+import { Editor, EditorContent } from "@tiptap/vue-3"
+import StarterKit from "@tiptap/starter-kit"
+
+let darkMode = ref(true)
+function toggleDarkMode() {
+  darkMode.value = !darkMode.value
+}
+const fonts = ["Sans-serif", "Serif"]
+let selectedFont = ref("San-serif")
+
+const editor = new Editor({
+  editable: false,
+  content: `
     <h1>Et Sollicitudin Ac Orci</h1>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -123,16 +141,9 @@
       dignissim. Condimentum id venenatis a condimentum vitae sapien
       pellentesque.
     </p>
-  </article>
-</template>
-<script setup>
-import { ref } from "vue"
-let darkMode = ref(true)
-let selectedFont = ref("San-serif")
-function toggleDarkMode() {
-  darkMode.value = !darkMode.value
-}
-const fonts = ["Sans-serif", "Serif"]
+      `,
+  extensions: [StarterKit],
+})
 </script>
 
 <style lang="sass" scoped>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1605,6 +1605,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-heading/-/extension-heading-2.0.0-beta.26.tgz#112b14b4d488772bda36abbf7cb2bc8aba7c42f5"
   integrity sha512-nR6W/3rjnZH1Swo7tGBoYsmO6xMvu9MGq6jlm3WVHCB7B3CsrRvCkTwGjVIbKTaZC4bQfx5gvAUpQFvwuU+M5w==
 
+"@tiptap/extension-highlight@^2.0.0-beta.33":
+  version "2.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-highlight/-/extension-highlight-2.0.0-beta.33.tgz#530b2f9bee8cb4f03cb587f1cf5ca11a23ebfcf8"
+  integrity sha512-TXyMiCcY5a0w5UFax350xU+T79GKJw2XwJ6Punc6sY2RRRgKaEbN1ZF0JCdQhQvD1ooKImHzCRYR8Pldb0xgfg==
+
 "@tiptap/extension-history@^2.0.0-beta.21":
   version "2.0.0-beta.21"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-history/-/extension-history-2.0.0-beta.21.tgz#5d96a17a83a7130744f0757a3275dd5b11eb1bf7"


### PR DESCRIPTION
This PR converts the statically mocked HTML into Tiptap content presented with Tiptap's Highlight extension.

Closes #979 