### PR TITLE
test(client): add error logging to cypress axe errors

### DIFF
--- a/client/test/cypress/integration/account.spec.js
+++ b/client/test/cypress/integration/account.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Account", () => {
   beforeEach(() => {
@@ -35,7 +36,7 @@ describe("Account", () => {
     cy.injectAxe()
     //Wait for the page to be loaded.
     cy.dataCy("vueAccount")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   // TODO: Uncomment once email updates work again

--- a/client/test/cypress/integration/admin/publication_details.spec.js
+++ b/client/test/cypress/integration/admin/publication_details.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../../support/helpers'
 
 describe("Publication Details", () => {
   beforeEach(() => {
@@ -25,7 +26,7 @@ describe("Publication Details", () => {
     cy.visit("/publication/1")
     cy.injectAxe()
     cy.dataCy("publication_details_heading")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of editors and reject assignments of duplicate editors", () => {
@@ -55,6 +56,6 @@ describe("Publication Details", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/admin/publications.spec.js
+++ b/client/test/cypress/integration/admin/publications.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../../support/helpers'
 
 describe("Admin Publications", () => {
   beforeEach(() => {
@@ -19,7 +20,7 @@ describe("Admin Publications", () => {
       .should("have.class", "bg-positive")
     cy.dataCy("new_publication_input").type("Draft Publication from Cypress")
     cy.get(".q-transition--field-message-leave-active").should("not.exist")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("prevents publication creation when the name is empty", () => {
@@ -27,7 +28,7 @@ describe("Admin Publications", () => {
     cy.dataCy("publications_list")
     cy.dataCy("name_field_error").should("be.visible")
     cy.dataCy("new_publication_input").type("Draft Publication from Cypress")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("prevents publication creation when the name exceeds the maximum length", () => {
@@ -38,7 +39,7 @@ describe("Admin Publications", () => {
     cy.dataCy("name_field_error").should("be.visible")
     cy.get(".q-transition--field-message-leave-active").should("not.exist")
     cy.get(".q-notification--top-enter-active").should("not.exist")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("prevents publication creation when the name is not unique", () => {
@@ -57,11 +58,11 @@ describe("Admin Publications", () => {
     cy.dataCy("name_field_error").should("be.visible")
     cy.get(".q-transition--field-message-leave-active").should("not.exist")
     cy.get(".q-notification--top-enter-active").should("not.exist")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should assert the initial load of the page is accessible", () => {
     cy.dataCy("create_new_publication_form")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/admin/user_details.spec.js
+++ b/client/test/cypress/integration/admin/user_details.spec.js
@@ -4,6 +4,7 @@
 // See https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
 
 import "cypress-axe"
+import { a11yLogViolations } from '../../support/helpers'
 
 describe("Admin User Details", () => {
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe("Admin User Details", () => {
     cy.visit("/admin/user/2")
     cy.injectAxe()
     cy.dataCy("userDetailsHeading")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should assert the User Details page of an non-admin is accessible", () => {
@@ -37,6 +38,6 @@ describe("Admin User Details", () => {
     cy.visit("/admin/user/1")
     cy.injectAxe()
     cy.dataCy("userDetailsHeading")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/admin/users.spec.js
+++ b/client/test/cypress/integration/admin/users.spec.js
@@ -4,6 +4,7 @@
 // See https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
 
 import "cypress-axe"
+import { a11yLogViolations } from '../../support/helpers'
 
 describe("Admin Users Index", () => {
   beforeEach(() => {
@@ -28,6 +29,6 @@ describe("Admin Users Index", () => {
     cy.visit("/admin/users")
     cy.injectAxe()
     cy.dataCy("userListBasicItem")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/dashboard.spec.js
+++ b/client/test/cypress/integration/dashboard.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Dashboard", () => {
   beforeEach(() => {
@@ -13,6 +14,6 @@ describe("Dashboard", () => {
     cy.injectAxe()
     //Wait for the page to be loaded.
     cy.dataCy("vueDashboard")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/home.spec.js
+++ b/client/test/cypress/integration/home.spec.js
@@ -8,6 +8,7 @@
 
 // This test will pass when run against a clean Quasar project
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Landing", () => {
   beforeEach(() => {
@@ -23,7 +24,7 @@ describe("Landing", () => {
     //Wait for page to be ready
     cy.dataCy("vueIndex")
     // check the page for a11y errors
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })
 describe("Home page tests", () => {

--- a/client/test/cypress/integration/login.spec.js
+++ b/client/test/cypress/integration/login.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("login page", () => {
   beforeEach(() => {
@@ -53,6 +54,6 @@ describe("login page", () => {
     // Inject the axe-core libraray
     cy.injectAxe()
     cy.dataCy("vueLogin")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/publications.spec.js
+++ b/client/test/cypress/integration/publications.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Publications", () => {
   it("creates new publications and checks the publications page", () => {
@@ -13,7 +14,7 @@ describe("Publications", () => {
     cy.visit("/publications")
     cy.injectAxe()
     cy.dataCy("publications_list").contains("Publication from Cypress")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("excludes the publications from the list when they are not publicly visible", () => {
@@ -22,6 +23,6 @@ describe("Publications", () => {
     // cy.visit("/publications")
     // cy.injectAxe()
     // cy.dataCy("publications_list").should("be.empty")
-    // cy.checkA11y()
+    // cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/register.spec.js
+++ b/client/test/cypress/integration/register.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Register", () => {
   beforeEach(() => {
@@ -106,6 +107,6 @@ describe("Register", () => {
       rules: {
         "autocomplete-valid": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/submissiondetails.spec.js
+++ b/client/test/cypress/integration/submissiondetails.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Submissions Details", () => {
   it("should assert the Submission Details page is accessible", () => {
@@ -10,7 +11,7 @@ describe("Submissions Details", () => {
     cy.visit("submission/100")
     cy.injectAxe()
     cy.dataCy("list_assigned_submitters")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of reviewers by application administrators", () => {
@@ -32,7 +33,7 @@ describe("Submissions Details", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 
   it("should allow assignments of reviewers by review coordinators", () => {
@@ -56,7 +57,7 @@ describe("Submissions Details", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 
   it("should allow assignments of review coordinators by application administrators", () => {
@@ -81,7 +82,7 @@ describe("Submissions Details", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 
   it("should disallow assignments of duplicate reviewers", () => {
@@ -103,6 +104,6 @@ describe("Submissions Details", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/submissionreview.spec.js
+++ b/client/test/cypress/integration/submissionreview.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 
 describe("Submissions Review", () => {
   it("should assert the Submission Review page is accessible", () => {
@@ -10,7 +11,7 @@ describe("Submissions Review", () => {
     cy.visit("submission/review/100")
     cy.injectAxe()
     cy.dataCy("submission_review_layout")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should assert the Submission Review page can be accessed from the dashboard", () => {

--- a/client/test/cypress/integration/submissions.spec.js
+++ b/client/test/cypress/integration/submissions.spec.js
@@ -2,6 +2,7 @@
 /// <reference path="../support/index.d.ts" />
 
 import "cypress-axe"
+import { a11yLogViolations } from '../support/helpers'
 import "cypress-file-upload"
 
 describe("Submissions", () => {
@@ -11,7 +12,7 @@ describe("Submissions", () => {
     cy.visit("submissions")
     cy.injectAxe()
     cy.dataCy("new_submission_title_input")
-    cy.checkA11y()
+    cy.checkA11y(null, null, a11yLogViolations)
     cy.dataCy("new_submission_title_input").type(
       "Submission from Cypress{enter}"
     )
@@ -32,7 +33,7 @@ describe("Submissions", () => {
       rules: {
         "nested-interactive": { enabled: false },
       },
-    })
+    }, a11yLogViolations)
     cy.reload()
     cy.dataCy("notification_indicator").should("be.visible")
   })

--- a/client/test/cypress/plugins/index.js
+++ b/client/test/cypress/plugins/index.js
@@ -43,6 +43,19 @@ module.exports = (on, config) => {
     },
   })
 
+  on('task', {
+    log(message) {
+      console.log(message)
+
+      return null
+    },
+    table(message) {
+      console.table(message)
+
+      return null
+    }
+  })
+
   on("before:browser:launch", (browser = {}, launchOptions) => {
     const REDUCE = 1
     if (browser.family === "firefox") {

--- a/client/test/cypress/support/helpers.js
+++ b/client/test/cypress/support/helpers.js
@@ -1,0 +1,31 @@
+export function a11yLogViolations(violations) {
+
+    function wrapTarget(target) {
+        return `${target}`.split("> ").map((e) => ({target: e}))
+    }
+    cy.task(
+        'log',
+        `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'
+        } ${violations.length === 1 ? 'was' : 'were'} detected`
+    )
+    // pluck specific keys to keep the table readable
+    const violationData = violations.map(
+        ({ id, impact, description, nodes }) => ({
+            id,
+            impact,
+            description,
+            nodes: nodes.length
+        })
+    )
+
+    cy.task('table', violationData)
+
+    const violationNodes = violations.map(
+        ({ id, nodes }) => nodes.map(({ target }) => {
+            const targetParts = wrapTarget(target)
+            return [{ id, target: targetParts[0].target }, ...targetParts.slice(1) ]
+        }).reduce((acc, e) => acc.concat(e, [{id: '====================', target: '-----------------------------------------------'}]), [])
+    ).reduce((acc, e) => acc.concat(e), [])
+
+    cy.task('table', violationNodes)
+}


### PR DESCRIPTION
Updates cypress axe errors from this: 
![image](https://user-images.githubusercontent.com/463159/164318294-91f430bd-53bf-48f9-addf-8021d6a46b15.png)

to this:
![image](https://user-images.githubusercontent.com/463159/164318344-34dbc92b-74c1-44a3-985f-9aee01184fde.png)
