### PR TITLE
Wreality/issue1056-fix-finduserselect

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "@tiptap/starter-kit": "^2.0.0-beta.184",
     "@tiptap/vue-3": "^2.0.0-beta.91",
     "@vue/apollo-composable": "^4.0.0-alpha.16",
-    "@vue/apollo-option": "^4.0.0-alpha.16",
+    "@vue/apollo-option": "^4.0.0-alpha.17",
     "@vuelidate/core": "^2.0.0-alpha.41",
     "@vuelidate/validators": "^2.0.0-alpha.29",
     "apollo-upload-client": "^17.0.0",

--- a/client/src/components/forms/FindUserSelect.vue
+++ b/client/src/components/forms/FindUserSelect.vue
@@ -4,12 +4,12 @@
     :options="options"
     bottom-slots
     hide-dropdown-icon
-    input-debounce="50"
     label="User to Assign"
     outlined
     transition-hide="none"
     transition-show="none"
     use-input
+    :loading="loading"
     @update:model-value="onSelectUpdate"
     @filter="filterFn"
   >
@@ -40,7 +40,7 @@
 </template>
 
 <script setup>
-import { useQuery } from "@vue/apollo-composable"
+import { useQuery, useResult } from "@vue/apollo-composable"
 import { SEARCH_USERS } from "src/graphql/queries"
 import { ref } from "vue"
 const props = defineProps({
@@ -64,15 +64,16 @@ function onSelectUpdate(newValue) {
   emit("update:modelValue", newValue)
 }
 
-const options = ref([])
-const { refetch } = useQuery(SEARCH_USERS)
+const variables = ref({ term: "" })
+const { result, loading, refetch } = useQuery(SEARCH_USERS, variables)
+const options = useResult(result, [], (data) => data.userSearch.data)
 
 async function filterFn(val, update) {
-  const newData = await refetch({ term: val.toLowerCase() })
-  const newOptions = newData.data.userSearch.data
+  variables.value = { term: val }
+  refetch()
 
-  update(() => {
-    options.value = newOptions
-  })
+  //Immediately call the update function to clear the loading flag for the filter
+  //The loading ref on the query will indicate loading to the user.
+  update(() => {})
 }
 </script>

--- a/client/test/cypress/integration/submissiondetails.spec.js
+++ b/client/test/cypress/integration/submissiondetails.spec.js
@@ -21,43 +21,27 @@ describe("Submissions Details", () => {
     cy.dataCy("input_review_assignee").type("applicationAd")
     cy.dataCy("result_review_assignee").click()
     cy.dataCy("review_assignee_selected").contains("applicationAdminUser")
-    cy.dataCy("input_review_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
+
     cy.dataCy("button_assign_reviewer").click()
     cy.dataCy("list_assigned_reviewers").contains("Application Administrator")
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
 
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of reviewers by review coordinators", () => {
     cy.task("resetDb")
     cy.login({ email: "reviewcoordinator@ccrproject.dev" })
     cy.visit("submission/100")
-    cy.dataCy("input_review_assignee").type("applicationAd{backspace}{backspace}")
+    cy.dataCy("input_review_assignee").type("applicationAd")
     cy.dataCy("result_review_assignee").click()
     cy.dataCy("review_assignee_selected").contains("applicationAdminUser")
-    cy.dataCy("input_review_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
     cy.dataCy("button_assign_reviewer").click()
     cy.dataCy("list_assigned_reviewers").contains("Application Administrator")
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
-    // Type characters to delay the a11y checker and prevent a false positive
-    // a11y violation before submission_details_notify fully fades in
-    cy.dataCy("input_review_assignee").type("allow notify to fully fade in")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of review coordinators by application administrators", () => {
@@ -69,20 +53,13 @@ describe("Submissions Details", () => {
     cy.dataCy("review_coordinator_assignee_selected").contains(
       "applicationAdminUser"
     )
-    cy.dataCy("input_review_coordinator_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
     cy.dataCy("button_assign_review_coordinator").click()
     cy.dataCy("list_assigned_review_coordinators").contains(
       "Application Administrator"
     )
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should disallow assignments of duplicate reviewers", () => {
@@ -100,10 +77,6 @@ describe("Submissions Details", () => {
     cy.dataCy("submission_details_notify")
       .should("be.visible")
       .should("have.class", "bg-negative")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2293,10 +2293,10 @@
     ts-essentials "^9.0.0"
     vue-demi "^0.12.1"
 
-"@vue/apollo-option@^4.0.0-alpha.16":
-  version "4.0.0-alpha.16"
-  resolved "https://registry.yarnpkg.com/@vue/apollo-option/-/apollo-option-4.0.0-alpha.16.tgz#bc1596da3095b263d738642a8fde86b5c5120d4a"
-  integrity sha512-MkNBzTZfVSV9qj/+EHD+CKxRLh1CwkCn3d6Ww4Ju8tQjkfsIac+im2do6qPeijrrd7z3CYV/SqPghVrz4QzNlA==
+"@vue/apollo-option@^4.0.0-alpha.17":
+  version "4.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/@vue/apollo-option/-/apollo-option-4.0.0-alpha.17.tgz#443b5a8e04145e30722a5159cd43f3609b61cc95"
+  integrity sha512-JDoQqbmWMlHMIVuzsHdNKp9AwDc+K1or5V0SsMeu9sf/JCEujmydQ+T/EBnXBLOOHwwJtGz6HlTud1V8ua2mlQ==
   dependencies:
     throttle-debounce "^3.0.1"
 


### PR DESCRIPTION
Updates find user select to work around graphql/apollo locking up on quick queries.  Bypasses the update mechanism from quasar to instead reactively update the query variables and call refetch on the original query which allows vueapollo to cancel duplicate queries on its own.

Closes #1056.