### PR TITLE
fix(client): Fix lockup in find-user-select component

### DIFF
--- a/client/src/components/forms/FindUserSelect.vue
+++ b/client/src/components/forms/FindUserSelect.vue
@@ -4,12 +4,12 @@
     :options="options"
     bottom-slots
     hide-dropdown-icon
-    input-debounce="50"
     label="User to Assign"
     outlined
     transition-hide="none"
     transition-show="none"
     use-input
+    :loading="loading"
     @update:model-value="onSelectUpdate"
     @filter="filterFn"
   >
@@ -40,7 +40,7 @@
 </template>
 
 <script setup>
-import { useQuery } from "@vue/apollo-composable"
+import { useQuery, useResult } from "@vue/apollo-composable"
 import { SEARCH_USERS } from "src/graphql/queries"
 import { ref } from "vue"
 const props = defineProps({
@@ -64,15 +64,16 @@ function onSelectUpdate(newValue) {
   emit("update:modelValue", newValue)
 }
 
-const options = ref([])
-const { refetch } = useQuery(SEARCH_USERS)
+const variables = ref({ term: "" })
+const { result, loading, refetch } = useQuery(SEARCH_USERS, variables)
+const options = useResult(result, [], (data) => data.userSearch.data)
 
 async function filterFn(val, update) {
-  const newData = await refetch({ term: val.toLowerCase() })
-  const newOptions = newData.data.userSearch.data
+  variables.value = { term: val }
+  refetch()
 
-  update(() => {
-    options.value = newOptions
-  })
+  //Immediately call the update function to clear the loading flag for the filter
+  //The loading ref on the query will indicate loading to the user.
+  update(() => {})
 }
 </script>

--- a/client/test/cypress/integration/admin/publication_details.spec.js
+++ b/client/test/cypress/integration/admin/publication_details.spec.js
@@ -54,11 +54,7 @@ describe("Publication Details", () => {
       .should("be.visible")
       .should("have.class", "bg-negative")
 
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow editing of style criteria", () => {

--- a/client/test/cypress/integration/submissiondetails.spec.js
+++ b/client/test/cypress/integration/submissiondetails.spec.js
@@ -21,43 +21,27 @@ describe("Submissions Details", () => {
     cy.dataCy("input_review_assignee").type("applicationAd")
     cy.dataCy("result_review_assignee").click()
     cy.dataCy("review_assignee_selected").contains("applicationAdminUser")
-    cy.dataCy("input_review_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
+
     cy.dataCy("button_assign_reviewer").click()
     cy.dataCy("list_assigned_reviewers").contains("Application Administrator")
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
 
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of reviewers by review coordinators", () => {
     cy.task("resetDb")
     cy.login({ email: "reviewcoordinator@ccrproject.dev" })
     cy.visit("submission/100")
-    cy.dataCy("input_review_assignee").type("applicationAd{backspace}{backspace}")
+    cy.dataCy("input_review_assignee").type("applicationAd")
     cy.dataCy("result_review_assignee").click()
     cy.dataCy("review_assignee_selected").contains("applicationAdminUser")
-    cy.dataCy("input_review_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
     cy.dataCy("button_assign_reviewer").click()
     cy.dataCy("list_assigned_reviewers").contains("Application Administrator")
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
-    // Type characters to delay the a11y checker and prevent a false positive
-    // a11y violation before submission_details_notify fully fades in
-    cy.dataCy("input_review_assignee").type("allow notify to fully fade in")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should allow assignments of review coordinators by application administrators", () => {
@@ -69,20 +53,13 @@ describe("Submissions Details", () => {
     cy.dataCy("review_coordinator_assignee_selected").contains(
       "applicationAdminUser"
     )
-    cy.dataCy("input_review_coordinator_assignee").type(
-      "test{backspace}{backspace}{backspace}{backspace}"
-    )
     cy.dataCy("button_assign_review_coordinator").click()
     cy.dataCy("list_assigned_review_coordinators").contains(
       "Application Administrator"
     )
     cy.injectAxe()
     cy.dataCy("submission_details_notify")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 
   it("should disallow assignments of duplicate reviewers", () => {
@@ -100,10 +77,6 @@ describe("Submissions Details", () => {
     cy.dataCy("submission_details_notify")
       .should("be.visible")
       .should("have.class", "bg-negative")
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
   })
 })

--- a/client/test/cypress/integration/submissions.spec.js
+++ b/client/test/cypress/integration/submissions.spec.js
@@ -29,11 +29,7 @@ describe("Submissions", () => {
     cy.dataCy("list_assigned_submitters").contains(
       "applicationadministrator@ccrproject.dev"
     )
-    cy.checkA11y(null, {
-      rules: {
-        "nested-interactive": { enabled: false },
-      },
-    }, a11yLogViolations)
+    cy.checkA11y(null, null, a11yLogViolations)
     cy.reload()
     cy.dataCy("notification_indicator").should("be.visible")
   })


### PR DESCRIPTION
Updates find user select to work around graphql/apollo locking up on quick queries. Bypasses the update mechanism from quasar to instead reactively update the query variables and call refetch on the original query which allows vueapollo to cancel duplicate queries on its own.

Once this gets merged it *should* clear up the two apollo dependabot PRs chillin in the open list.

Closes #1056.