### PR TITLE
WIP: Annotations functionality playground

### DIFF
--- a/client/src/components/atoms/SubmissionComment.vue
+++ b/client/src/components/atoms/SubmissionComment.vue
@@ -1,5 +1,12 @@
 <template>
-  <q-card square class="bg-grey-1 shadow-2 q-mb-md">
+  <div ref="scrollTarget" />
+  <q-card
+    ref="cardRef"
+    square
+    class="bg-grey-1 shadow-2 q-mb-md"
+    :class="active ? 'active' : ''"
+    @click="onClick"
+  >
     <q-separator :color="props.isInlineComment ? `blue-1` : `grey-3`" />
     <q-card-section
       class="q-py-xs"
@@ -119,13 +126,13 @@
   </section>
 </template>
 <script setup>
-import { ref } from "vue"
+import { computed, inject, ref, watch } from "vue"
 import AvatarImage from "./AvatarImage.vue"
 import CommentActions from "./CommentActions.vue"
 import CommentEditor from "../forms/CommentEditor.vue"
 const user = { email: "commenter@example.com" }
 const user2 = { email: "magnafringilla@example.com" }
-const isCollapsed = ref(false)
+const isCollapsed = ref(true)
 const isReplying = ref(false)
 function toggleThread() {
   isCollapsed.value = !isCollapsed.value
@@ -148,12 +155,38 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  comment: {
+    type: Object,
+    default: () => ({}),
+  },
 })
 
+const activeComment = inject("activeComment")
+const active = computed(() => {
+  return activeComment.value === props.comment.id
+})
+
+watch(active, (newValue) => {
+  isCollapsed.value = !newValue
+})
 function cancelReply() {
   isReplying.value = false
 }
 function initiateReply() {
   isReplying.value = true
 }
+function onClick() {
+  activeComment.value = props.comment.id
+}
+
+const scrollTarget = ref(null)
+defineExpose({
+  scrollTarget,
+})
 </script>
+
+<style>
+.q-card.active {
+  border: 2px yellow solid;
+}
+</style>

--- a/client/src/components/atoms/SubmissionCommentDrawer.vue
+++ b/client/src/components/atoms/SubmissionCommentDrawer.vue
@@ -20,14 +20,20 @@
             <span class="text-h3"> Inline Comments </span>
           </div>
           <q-card
+            v-if="false"
             class="q-ma-md q-pa-md bg-grey-1"
             bordered
             style="border-color: rgb(56, 118, 187)"
           >
             <comment-editor :is-inline-comment="true" />
           </q-card>
-          <submission-comment is-inline-comment />
-          <submission-comment is-inline-comment />
+          <submission-comment
+            v-for="comment in comments"
+            ref="commentsRefs"
+            :key="comment.id"
+            :comment="comment"
+            is-inline-comment
+          />
           <div class="row justify-center q-pa-md q-pb-xl">
             <q-btn color="dark" icon="arrow_upward">Scroll to Top</q-btn>
           </div>
@@ -38,9 +44,12 @@
 </template>
 
 <script setup>
-import { ref, watch } from "vue"
+import { ref, watch, inject, nextTick } from "vue"
 import SubmissionComment from "src/components/atoms/SubmissionComment.vue"
 import CommentEditor from "src/components/forms/CommentEditor.vue"
+import { scroll } from "quasar"
+
+const { getScrollTarget, setVerticalScrollPosition } = scroll
 
 const drawerWidth = ref(440)
 let originalWidth
@@ -65,5 +74,21 @@ const props = defineProps({
 const DrawerOpen = ref(props.commentDrawerOpen)
 watch(props, () => {
   DrawerOpen.value = props.commentDrawerOpen
+})
+const comments = inject("comments")
+const commentsRefs = ref([])
+const activeComment = inject("activeComment")
+
+watch(activeComment, (newValue) => {
+  if (!newValue) return
+  nextTick(() => {
+    //TODO: There's a potential problem here since per Vue's docs the order of refs in the array is not guarenteed to match the order of the v-fot array
+    //TODO: Solution: Since the ref is a component ref, expose an id that can be used to find the correct component directly in the refs array
+    const index = comments.value.findIndex((o) => o.id === newValue)
+    const el = commentsRefs.value[index].scrollTarget
+    const target = getScrollTarget(el)
+    const offset = el.offsetTop
+    setVerticalScrollPosition(target, offset, 250)
+  })
 })
 </script>

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -36,7 +36,7 @@
       />
     </div>
   </div>
-  <article class="col-sm-9 submission-content">
+  <article ref="contentRef" class="col-sm-9 submission-content">
     <editor-content :editor="editor" />
   </article>
 </template>
@@ -52,9 +52,35 @@ function toggleDarkMode() {
 }
 const fonts = ["Sans-serif", "Serif"]
 let selectedFont = ref("San-serif")
+const contentRef = ref(null)
 const activeComment = inject("activeComment")
-const onAnnotationClick = (context) => {
-  activeComment.value = context.id
+const onAnnotationClick = (context, { target }) => {
+  //First we need to get all the comment widget elements
+  const widgets = [...contentRef.value.querySelectorAll(".lint-icon")]
+    .filter((e) => e.offsetTop === target.offsetTop)
+    .map((e) => e.dataset.comment)
+
+  //Only one comment here. We're done
+  if (widgets.length === 1) {
+    activeComment.value = context.id
+    return
+  }
+  const currentIndex = widgets.indexOf(activeComment.value)
+
+  //The active comment isn't one of these, show the first
+  if (currentIndex === -1) {
+    activeComment.value = widgets[0]
+    return
+  }
+
+  //We're at the last in the lit, start over
+  if (currentIndex + 1 === widgets.length) {
+    activeComment.value = widgets[0]
+    return
+  }
+
+  //Next in the list
+  activeComment.value = widgets[currentIndex + 1]
 }
 //TODO: Comments will ideally be provided as part of the submission, either via prop or injection
 const comments = inject("comments")

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -41,7 +41,7 @@
   </article>
 </template>
 <script setup>
-import { ref, computed } from "vue"
+import { ref, computed, inject } from "vue"
 import { Editor, EditorContent } from "@tiptap/vue-3"
 import Highlight from "@tiptap/extension-highlight"
 import StarterKit from "@tiptap/starter-kit"
@@ -52,22 +52,19 @@ function toggleDarkMode() {
 }
 const fonts = ["Sans-serif", "Serif"]
 let selectedFont = ref("San-serif")
+const activeComment = inject("activeComment")
 const onAnnotationClick = (context) => {
-  console.log(context)
+  activeComment.value = context.id
 }
-const comments = ref([
-  { from: 123, to: 125, id: "one" },
-  { from: 8, to: 43, id: "two" },
-  { from: 8, to: 43, id: "eithg" },
-  { from: 100, to: 122, id: "three" },
-  { from: 300, to: 322, id: "four" },
-])
+//TODO: Comments will ideally be provided as part of the submission, either via prop or injection
+const comments = inject("comments")
 
 const annotations = computed(() =>
   comments.value.map(({ from, to, id }) => ({
     from,
     to,
     context: { id },
+    active: id === activeComment.value,
     click: onAnnotationClick,
   }))
 )
@@ -169,6 +166,9 @@ const editor = new Editor({
 <style lang="scss">
 .comment-highlight {
   background: #ddd;
+}
+.comment-highlight.active {
+  background: rgb(255, 254, 169);
 }
 .comment-highlight2 {
   background: rgba(120, 0, 100, 0.5);

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -41,17 +41,36 @@
   </article>
 </template>
 <script setup>
-import { ref } from "vue"
+import { ref, computed } from "vue"
 import { Editor, EditorContent } from "@tiptap/vue-3"
 import Highlight from "@tiptap/extension-highlight"
 import StarterKit from "@tiptap/starter-kit"
-
+import AnnotationExtension from "src/tiptap/annotation-extension"
 let darkMode = ref(true)
 function toggleDarkMode() {
   darkMode.value = !darkMode.value
 }
 const fonts = ["Sans-serif", "Serif"]
 let selectedFont = ref("San-serif")
+const onAnnotationClick = (context) => {
+  console.log(context)
+}
+const comments = ref([
+  { from: 123, to: 125, id: "one" },
+  { from: 8, to: 43, id: "two" },
+  { from: 8, to: 43, id: "eithg" },
+  { from: 100, to: 122, id: "three" },
+  { from: 300, to: 322, id: "four" },
+])
+
+const annotations = computed(() =>
+  comments.value.map(({ from, to, id }) => ({
+    from,
+    to,
+    context: { id },
+    click: onAnnotationClick,
+  }))
+)
 
 const editor = new Editor({
   editable: false,
@@ -64,9 +83,9 @@ const editor = new Editor({
       justo donec enim diam vulputate ut. Eget lorem dolor sed viverra ipsum
       nunc. Ut tortor pretium viverra suspendisse potenti nullam ac tortor
       vitae.
-      <mark>Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Et
+      Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Et
         egestas quis ipsum suspendisse ultrices gravida. In est ante in nibh
-        mauris cursus mattis.</mark>
+        mauris cursus mattis.
       Amet purus gravida quis blandit turpis cursus. Auctor neque vitae tempus
       quam pellentesque nec nam aliquam sem. At consectetur lorem donec massa
       sapien faucibus. Et ultrices neque ornare aenean. Hac habitasse platea
@@ -106,9 +125,9 @@ const editor = new Editor({
       rhoncus dolor purus non enim. In nisl nisi scelerisque eu ultrices. Tempor
       commodo ullamcorper a lacus vestibulum. Nisl nisi scelerisque eu ultrices
       vitae auctor eu. Urna id volutpat
-      <mark>lacus laoreet non curabitur. Dolor magna eget est lorem ipsum dolor.
+      lacus laoreet non curabitur. Dolor magna eget est lorem ipsum dolor.
         Mauris vitae ultricies leo integer malesuada nunc vel risus
-        commodo.</mark>
+        commodo.
     </p>
     <h3>Commodo quis</h3>
     <p>
@@ -139,53 +158,17 @@ const editor = new Editor({
       pellentesque.
     </p>
       `,
-  extensions: [StarterKit, Highlight],
-})
-editor.registerPlugin(testPlugin)
-</script>
-
-<script>
-import { Plugin } from "prosemirror-state"
-import { Decoration, DecorationSet } from "prosemirror-view"
-
-function getDecorations(doc) {
-  let decos = [
-    Decoration.inline(8, 25, { class: "comment-highlight" }),
-    Decoration.inline(20, 43, { class: "comment-highlight2" }),
-    Decoration.inline(100, 122, { class: "comment-highlight" }),
-    Decoration.inline(300, 322, { class: "comment-highlight2" }),
-    Decoration.widget(300, lintIcon()),
-    Decoration.widget(302, lintIcon()),
-  ]
-  return DecorationSet.create(doc, decos)
-}
-function lintIcon() {
-  let icon = document.createElement("div")
-  icon.className = "lint-icon"
-
-  return icon
-}
-
-let testPlugin = new Plugin({
-  state: {
-    init(_, { doc }) {
-      return getDecorations(doc)
-    },
-    apply(tr) {
-      return getDecorations(tr.doc)
-    },
-  },
-  props: {
-    decorations(state) {
-      return this.getState(state)
-    },
-  },
+  extensions: [
+    StarterKit,
+    Highlight,
+    AnnotationExtension.configure({ annotations }),
+  ],
 })
 </script>
 
 <style lang="scss">
 .comment-highlight {
-  text-decoration: underline;
+  background: #ddd;
 }
 .comment-highlight2 {
   background: rgba(120, 0, 100, 0.5);
@@ -226,17 +209,11 @@ mark {
 
 .lint-icon {
   display: inline-block;
-  right: 2px;
   cursor: pointer;
-  float: right;
-  border-radius: 100px;
-  background: #f22;
-  color: white;
-  font-family: times, georgia, serif;
-  font-size: 15px;
-  font-weight: bold;
-  width: 1.1em;
-  height: 1.1em;
+  position: absolute;
+  right: -50px;
+  font-size: 1.4rem;
+  color: $primary;
   text-align: center;
   padding-left: 0.5px;
   line-height: 1.1em;

--- a/client/src/components/atoms/SubmissionContent.vue
+++ b/client/src/components/atoms/SubmissionContent.vue
@@ -141,9 +141,55 @@ const editor = new Editor({
       `,
   extensions: [StarterKit, Highlight],
 })
+editor.registerPlugin(testPlugin)
+</script>
+
+<script>
+import { Plugin } from "prosemirror-state"
+import { Decoration, DecorationSet } from "prosemirror-view"
+
+function getDecorations(doc) {
+  let decos = [
+    Decoration.inline(8, 25, { class: "comment-highlight" }),
+    Decoration.inline(20, 43, { class: "comment-highlight2" }),
+    Decoration.inline(100, 122, { class: "comment-highlight" }),
+    Decoration.inline(300, 322, { class: "comment-highlight2" }),
+    Decoration.widget(300, lintIcon()),
+    Decoration.widget(302, lintIcon()),
+  ]
+  return DecorationSet.create(doc, decos)
+}
+function lintIcon() {
+  let icon = document.createElement("div")
+  icon.className = "lint-icon"
+
+  return icon
+}
+
+let testPlugin = new Plugin({
+  state: {
+    init(_, { doc }) {
+      return getDecorations(doc)
+    },
+    apply(tr) {
+      return getDecorations(tr.doc)
+    },
+  },
+  props: {
+    decorations(state) {
+      return this.getState(state)
+    },
+  },
+})
 </script>
 
 <style lang="scss">
+.comment-highlight {
+  text-decoration: underline;
+}
+.comment-highlight2 {
+  background: rgba(120, 0, 100, 0.5);
+}
 .submission-content {
   counter-reset: paragraph_counter;
   font-size: 16px;
@@ -159,6 +205,7 @@ const editor = new Editor({
 .submission-content p:before {
   color: #555;
   content: "¶ " counter(paragraph_counter);
+  right: 0px;
   counter-increment: paragraph_counter;
   display: block;
   font-family: Helvetica, Arial, san-serif;
@@ -175,5 +222,23 @@ const editor = new Editor({
 mark {
   color: #000;
   background-color: #bbe2e8;
+}
+
+.lint-icon {
+  display: inline-block;
+  right: 2px;
+  cursor: pointer;
+  float: right;
+  border-radius: 100px;
+  background: #f22;
+  color: white;
+  font-family: times, georgia, serif;
+  font-size: 15px;
+  font-weight: bold;
+  width: 1.1em;
+  height: 1.1em;
+  text-align: center;
+  padding-left: 0.5px;
+  line-height: 1.1em;
 }
 </style>

--- a/client/src/pages/SubmissionReview.vue
+++ b/client/src/pages/SubmissionReview.vue
@@ -40,14 +40,25 @@ const props = defineProps({
     required: true,
   },
 })
+const commentDrawerOpen = ref(true)
+
 const { result } = useQuery(GET_SUBMISSION, { id: props.id })
 const submission = computed(() => {
   return result.value?.submission
 })
 
 provide("submission", submission)
+provide("activeComment", ref(1))
+//TODO: comments will ideally be provided as part of the submission query, but providing separately for mocking purposes
 
-const commentDrawerOpen = ref(true)
+const someLorem =
+  "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex eveniet dolorum reprehenderit libero officia veritatis quidem ratione corporis dignissimos qui cupiditate maiores consequatur, distinctio soluta, quos ut, magni rem! Iste."
+const comments = ref([
+  { id: 1, content: someLorem, from: 100, to: 200 },
+  { id: 2, content: someLorem, from: 220, to: 310 },
+  { id: 3, content: someLorem, from: 520, to: 810 },
+])
+provide("comments", comments)
 </script>
 
 <style lang="sass" scoped>

--- a/client/src/pages/SubmissionReview.vue
+++ b/client/src/pages/SubmissionReview.vue
@@ -54,9 +54,10 @@ provide("activeComment", ref(1))
 const someLorem =
   "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex eveniet dolorum reprehenderit libero officia veritatis quidem ratione corporis dignissimos qui cupiditate maiores consequatur, distinctio soluta, quos ut, magni rem! Iste."
 const comments = ref([
-  { id: 1, content: someLorem, from: 100, to: 200 },
-  { id: 2, content: someLorem, from: 220, to: 310 },
-  { id: 3, content: someLorem, from: 520, to: 810 },
+  { id: "1", content: someLorem, from: 100, to: 200 },
+  { id: "2", content: someLorem, from: 220, to: 310 },
+  { id: "4", content: someLorem, from: 220, to: 229 },
+  { id: "3", content: someLorem, from: 520, to: 810 },
 ])
 provide("comments", comments)
 </script>

--- a/client/src/tiptap/AnnotationPlugin.js
+++ b/client/src/tiptap/AnnotationPlugin.js
@@ -8,7 +8,7 @@ function getDecorations(doc, annotations) {
   const decorations = annotations
     .map((a) => [
       Decoration.inline(a.from, a.to, {
-        class: "comment-highlight",
+        class: `comment-highlight ${a.active ? "active" : ""}`,
         ...a.context,
       }),
       Decoration.widget(a.from, lintIcon(a)),

--- a/client/src/tiptap/AnnotationPlugin.js
+++ b/client/src/tiptap/AnnotationPlugin.js
@@ -1,0 +1,50 @@
+import { Plugin, PluginKey } from "prosemirror-state"
+//import { AnnotationState } from './AnnotationState'
+import { DecorationSet, Decoration } from "prosemirror-view"
+
+export const AnnotationPluginKey = new PluginKey("annotation")
+
+function getDecorations(doc, annotations) {
+  const decorations = annotations
+    .map((a) => [
+      Decoration.inline(a.from, a.to, {
+        class: "comment-highlight",
+        ...a.context,
+      }),
+      Decoration.widget(a.from, lintIcon(a)),
+    ])
+    .reduce((a, c) => [...a, ...c], [])
+  console.table(decorations)
+
+  return decorations.length ? DecorationSet.create(doc, decorations) : null
+}
+function lintIcon({ click, context }) {
+  let icon = document.createElement("i")
+  icon.className = "q-icon material-icons lint-icon"
+  icon.innerText = "chat_bubble"
+  icon.onclick = () => click(context)
+  return icon
+}
+export const AnnotationPlugin = () =>
+  new Plugin({
+    key: AnnotationPluginKey,
+
+    state: {
+      init(_, { doc }) {
+        return getDecorations(doc, [])
+      },
+      apply(transaction, state) {
+        const action = transaction.getMeta(AnnotationPluginKey)
+        if (action) {
+          return getDecorations(transaction.doc, action.annotations)
+        }
+        return state
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return this.getState(state)
+      },
+    },
+  })

--- a/client/src/tiptap/AnnotationPlugin.js
+++ b/client/src/tiptap/AnnotationPlugin.js
@@ -22,7 +22,8 @@ function lintIcon({ click, context }) {
   let icon = document.createElement("i")
   icon.className = "q-icon material-icons lint-icon"
   icon.innerText = "chat_bubble"
-  icon.onclick = () => click(context)
+  icon.dataset.comment = context.id
+  icon.onclick = (...args) => click(context, ...args)
   return icon
 }
 export const AnnotationPlugin = () =>

--- a/client/src/tiptap/annotation-extension.js
+++ b/client/src/tiptap/annotation-extension.js
@@ -1,0 +1,90 @@
+import { watch } from "vue"
+import { AnnotationPluginKey, AnnotationPlugin } from "./AnnotationPlugin"
+import { Extension } from "@tiptap/vue-3"
+export default Extension.create({
+  name: "annotation",
+
+  priority: 1000,
+
+  defaultOptions: {
+    HTMLAttributes: {
+      class: "annotation",
+    },
+    onUpdate: (decorations) => decorations,
+  },
+
+  onCreate() {
+    const updateAnnotations = (annotations) => {
+      console.log(`annotations updated`)
+
+      const transaction = this.editor.state.tr.setMeta(AnnotationPluginKey, {
+        type: "createDecorations",
+        annotations,
+      })
+
+      this.editor.view.dispatch(transaction)
+    }
+    watch(this.options.annotations, updateAnnotations)
+    updateAnnotations(this.options.annotations.value)
+  },
+
+  addCommands() {
+    return {
+      addAnnotation:
+        (data) =>
+        ({ dispatch, state }) => {
+          const { selection } = state
+
+          if (selection.empty) {
+            return false
+          }
+
+          if (dispatch && data) {
+            state.tr.setMeta(AnnotationPluginKey, {
+              type: "addAnnotation",
+              from: selection.from,
+              to: selection.to,
+              data,
+            })
+          }
+
+          return true
+        },
+      updateAnnotation:
+        (id, data) =>
+        ({ dispatch, state }) => {
+          if (dispatch) {
+            state.tr.setMeta(AnnotationPluginKey, {
+              type: "updateAnnotation",
+              id,
+              data,
+            })
+          }
+
+          return true
+        },
+      deleteAnnotation:
+        (id) =>
+        ({ dispatch, state }) => {
+          if (dispatch) {
+            state.tr.setMeta(AnnotationPluginKey, {
+              type: "deleteAnnotation",
+              id,
+            })
+          }
+
+          return true
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      AnnotationPlugin({
+        HTMLAttributes: this.options.HTMLAttributes,
+        onUpdate: this.options.onUpdate,
+        instance: this.options.instance,
+      }),
+    ]
+  },
+})


### PR DESCRIPTION
NOTE: NOT INTENDED FOR MERGE

This add a annotations extension to tiptap that includes a prosemirror plugin to make reactive annotations.

This isn't intended to be a final suggestion just playing with what the tiptap and prosemirror API's may make possible without reinventing the wheel, and exploring ways they can work with our existing components.

While this doesn't solve the overlapping comments widgets issue (the comment icon on the right of the content) I do think I've found a way to swap in a different element when widgets are overlapping and allow toggling through.  More to come on that however.

Things that DO work so far:
Clicking an widget (again, comment icon floated right of content) will change the highlight for the commented text, add a highlight to the comment itself in the comment drawer and scroll-to the active comment
Clicking a comment (parent comment) will highlight the comment in the content (and as a meh side effect, will scroll the drawer to the comment)
![comments-play](https://user-images.githubusercontent.com/463159/169375140-7d0eb68d-8070-4eae-bb6a-3ab7aebb7c3a.gif)

