### PR TITLE
fix: Alignment in Bypass Style Criteria Dialog

### DIFF
--- a/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
+++ b/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
@@ -10,7 +10,7 @@
             <i18n-t keypath="dialog.bypassStyleCriteria.line_1" tag="span">
               <template #link>
                 <a
-                  href="https://publicphilosophyjournal.org/about-community-collaborative-review/"
+                  href="https://publicphilosophyjournal.org/overview/"
                   target="_blank"
                 >
                   {{ $t("dialog.bypassStyleCriteria.line_1_linktext") }}

--- a/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
+++ b/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
@@ -1,12 +1,12 @@
 <template>
   <q-dialog ref="dialogRef" @hide="onDialogHide">
     <q-card>
-      <q-card-section class="row">
-        <div class="q-pa-sm column">
+      <q-card-section class="row no-wrap">
+        <div class="q-pa-sm q-pr-md column">
           <q-avatar icon="toggle_on" color="primary" text-color="white" />
         </div>
-        <div class="column justify-center q-pr-md">
-          <p class="q-ml-sm q-mb-none">
+        <div class="column justify-center q-my-sm q-mb-none">
+          <p class="q-mb-none">
             <i18n-t keypath="dialog.bypassStyleCriteria.line_1" tag="span">
               <template #link>
                 <a
@@ -18,7 +18,7 @@
               </template>
             </i18n-t>
           </p>
-          <p class="q-ml-sm q-mb-none">
+          <p class="q-mb-none">
             {{ $t("dialog.bypassStyleCriteria.line_2") }}
           </p>
         </div>

--- a/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
+++ b/client/src/components/dialogs/BypassStyleCriteriaDialog.vue
@@ -10,7 +10,7 @@
             <i18n-t keypath="dialog.bypassStyleCriteria.line_1" tag="span">
               <template #link>
                 <a
-                  href="https://publicphilosophyjournal.org/overview/"
+                  href="https://publicphilosophyjournal.org/about-community-collaborative-review/"
                   target="_blank"
                 >
                   {{ $t("dialog.bypassStyleCriteria.line_1_linktext") }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ actionLink: /install/
 ---
 # About
 
-Collaborative Community Review (CCR) is an open source web tool representing the values and intent of [Collaborative Community Review (CCR)](https://publicphilosophyjournal.org/overview/) as established by the [Public Philosophy Journal](https://publicphilosophyjournal.com). CCR will provide a collaboration framework for the review of submissions intended for publication by journals, publications, bloggers, and more. CCR will be used to satisfy the various needs of the peer review process for works in academic and public scholarship. CCR is primarily funded through a grant by the Andrew Mellon Foundation.
+Collaborative Community Review (CCR) is an open source web tool representing the values and intent of [Collaborative Community Review (CCR)](https://publicphilosophyjournal.org/about-community-collaborative-review) as established by the [Public Philosophy Journal](https://publicphilosophyjournal.org). CCR will provide a collaboration framework for the review of submissions intended for publication by journals, publications, bloggers, and more. CCR will be used to satisfy the various needs of the peer review process for works in academic and public scholarship. CCR is primarily funded through a grant by the Andrew Mellon Foundation.
 
 ## Project Sponsors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ actionLink: /install/
 ---
 # About
 
-Collaborative Community Review (CCR) is an open source web tool representing the values and intent of [Collaborative Community Review (CCR)](https://publicphilosophyjournal.org/about-community-collaborative-review) as established by the [Public Philosophy Journal](https://publicphilosophyjournal.org). CCR will provide a collaboration framework for the review of submissions intended for publication by journals, publications, bloggers, and more. CCR will be used to satisfy the various needs of the peer review process for works in academic and public scholarship. CCR is primarily funded through a grant by the Andrew Mellon Foundation.
+Collaborative Community Review (CCR) is an open source web tool representing the values and intent of [Collaborative Community Review (CCR)](https://publicphilosophyjournal.org/overview/) as established by the [Public Philosophy Journal](https://publicphilosophyjournal.com). CCR will provide a collaboration framework for the review of submissions intended for publication by journals, publications, bloggers, and more. CCR will be used to satisfy the various needs of the peer review process for works in academic and public scholarship. CCR is primarily funded through a grant by the Andrew Mellon Foundation.
 
 ## Project Sponsors
 


### PR DESCRIPTION
This PR fixes the wrapping and alignment issue between the dialog text and icon in `BypassStyleCriteriaDialog.vue`

![A left/right comparison showing what the dialog before and after fixing the alignment issue](https://user-images.githubusercontent.com/2668987/170355428-db19d8aa-e82d-40b4-825a-29e8e8fda3c8.png)

I discovered the [previous PR that was open for this](https://github.com/MESH-Research/CCR/pull/1132) was accidentally closed after I had renamed the branch. Lesson: rename branches before opening pull requests.