### PR TITLE
fix: Namespace Discrepancy in Logout.php

### DIFF
--- a/backend/app/GraphQL/Mutations/Login.php
+++ b/backend/app/GraphQL/Mutations/Login.php
@@ -1,11 +1,11 @@
 <?php
- declare(strict_types=1);
+declare(strict_types=1);
 
- namespace App\GraphQL\Mutations;
+namespace App\GraphQL\Mutations;
 
- use App\Exceptions\InvalidCredentials;
- use App\Models\User;
- use Illuminate\Support\Facades\Auth;
+use App\Exceptions\InvalidCredentials;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 class Login
 {

--- a/backend/app/GraphQL/Mutations/Logout.php
+++ b/backend/app/GraphQL/Mutations/Logout.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Graphql\Mutations;
+namespace App\GraphQL\Mutations;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;


### PR DESCRIPTION
This PR fixes a warning on `Logout.php` encountered when rebuilding: 

```
Class App\Graphql\Mutations\Logout located in ./app/GraphQL/Mutations/Logout.php does not comply with psr-4 autoloading standard. Skipping.
```

Before:

<img width="1440" alt="Screenshot showing the warning appearing in the command line after running a rebuild" src="https://user-images.githubusercontent.com/2668987/170506143-c8748f4c-ba09-45e9-8253-5d46adb6d68c.png">


After:

<img width="1440" alt="Screenshot showing the warning no longer appearing in the command line" src="https://user-images.githubusercontent.com/2668987/170506233-4e212dfd-d2f2-49ca-93c7-efc4957f456a.png">

Bonus: this PR also removes some extra whitespace in `Login.php`

