### PR TITLE
refactor(api): move seeder calls into seeder classes

### DIFF
--- a/backend/database/factories/StyleCriteriaFactory.php
+++ b/backend/database/factories/StyleCriteriaFactory.php
@@ -22,8 +22,14 @@ class StyleCriteriaFactory extends Factory
      */
     public function definition()
     {
+        $name = $this->faker->streetName;
+        //Occasionally streetName is longer than the validatable length for this field (20 chars).
+        if (mb_strlen($name) > 20) {
+            $name = substr($name, 0, 20);
+        }
+
         return [
-            'name' => $this->faker->streetName,
+            'name' => $name,
             'description' => '<p>' . $this->faker->paragraph(3, true) . '</p>',
             'icon' => $this->faker->randomElement($this->iconOptions),
         ];

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -3,10 +3,7 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-use App\Models\Role;
-use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,73 +14,14 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $admin = User::factory()->create([
-            'username' => 'applicationAdminUser',
-            'email' => 'applicationadministrator@ccrproject.dev',
-            'name' => 'Application Administrator',
-            'password' => Hash::make('adminPassword!@#'),
+        $this->call([
+            UserSeeder::class,
+            PublicationSeeder::class,
+            StyleCriteriasSeeder::class,
+            SubmissionSeeder::class,
+            SubmissionFileSeeder::class,
+            InlineCommentSeeder::class,
+            OverallCommentSeeder::class,
         ]);
-
-        $publication_admin = User::factory()->create([
-            'username' => 'publicationAdministrator',
-            'email' => 'publicationAdministrator@ccrproject.dev',
-            'name' => 'Publication Administrator',
-            'password' => Hash::make('publicationadminPassword!@#'),
-        ]);
-
-        $editor = User::factory()->create([
-            'username' => 'publicationEditor',
-            'email' => 'publicationEditor@ccrproject.dev',
-            'name' => 'Publication Editor',
-            'password' => Hash::make('editorPassword!@#'),
-        ]);
-
-        User::factory()->create([
-            'username' => 'reviewCoordinator',
-            'email' => 'reviewCoordinator@ccrproject.dev',
-            'name' => 'Review Coordinator for Submission',
-            'password' => Hash::make('coordinatorPassword!@#'),
-        ]);
-
-        User::factory()->create([
-            'username' => 'reviewer',
-            'email' => 'reviewer@ccrproject.dev',
-            'name' => 'Reviewer for Submission',
-            'password' => Hash::make('reviewerPassword!@#'),
-        ]);
-
-        User::factory()->create([
-            'username' => 'regularUser',
-            'email' => 'regularuser@ccrproject.dev',
-            'name' => 'Regular User',
-            'password' => Hash::make('regularPassword!@#'),
-        ]);
-
-        $admin->assignRole(Role::APPLICATION_ADMINISTRATOR);
-        $publication_admin->assignRole(Role::PUBLICATION_ADMINISTRATOR);
-        $editor->assignRole(Role::EDITOR);
-
-        $publication_seeder = new PublicationSeeder();
-        $publication_seeder->run($publication_admin, $editor);
-
-        $submission_seeder = new SubmissionSeeder();
-        $submission_seeder->run(100, 'CCR Test Submission 1');
-        $submission_seeder->run(101, 'CCR Test Submission 2');
-
-        $style_criterias_seeder = new StyleCriteriasSeeder();
-        $style_criterias_seeder->run();
-
-        $submission_file_seeder = new SubmissionFileSeeder();
-        $submission_file_seeder->run();
-
-        $inlineCommentSeeder = new InlineCommentSeeder();
-        $inlineCommentSeeder->run(100, ['replies' => 1, 'highlight' => [30, 80]]);
-        $inlineCommentSeeder->run(100, ['highlight' => [430, 445]]);
-        $inlineCommentSeeder->run(100, ['replies' => 10, 'highlight' => [630, 720]]);
-
-        $overallCommentSeeder = new OverallCommentSeeder();
-        $overallCommentSeeder->run(100);
-        $overallCommentSeeder->run(100, 1);
-        $overallCommentSeeder->run(100, 8);
     }
 }

--- a/backend/database/seeders/InlineCommentSeeder.php
+++ b/backend/database/seeders/InlineCommentSeeder.php
@@ -19,13 +19,26 @@ class InlineCommentSeeder extends Seeder
     ];
 
     /**
+     * Run the seeder
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->callOnce(SubmissionSeeder::class);
+        $this->create(100, ['replies' => 1, 'highlight' => [30, 80]]);
+        $this->create(100, ['highlight' => [430, 445]]);
+        $this->create(100, ['replies' => 10, 'highlight' => [630, 720]]);
+    }
+
+    /**
      * Run the database seeds.
      *
      * @param int $submissionId
      * @param array $options
      * @return void
      */
-    public function run($submissionId, $options = [])
+    public function create($submissionId, $options = [])
     {
         $opts = array_merge($this->defaultOptions, $options);
         $userIds = User::all()->pluck('id');

--- a/backend/database/seeders/OverallCommentSeeder.php
+++ b/backend/database/seeders/OverallCommentSeeder.php
@@ -12,13 +12,27 @@ use Illuminate\Database\Seeder;
 class OverallCommentSeeder extends Seeder
 {
     /**
+     * Run the seeder
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->callOnce(SubmissionSeeder::class);
+
+        $this->create(100);
+        $this->create(100, 1);
+        $this->create(100, 8);
+    }
+
+    /**
      * Run the database seeds.
      *
      * @param int $submissionId
      * @param int $replies
      * @return void
      */
-    public function run($submissionId, $replies = 0)
+    protected function create($submissionId, $replies = 0)
     {
         $userIds = User::all()->pluck('id');
         $userId = $userIds->random();

--- a/backend/database/seeders/PublicationSeeder.php
+++ b/backend/database/seeders/PublicationSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 
 use App\Models\Publication;
 use App\Models\Role;
+use App\Models\StyleCriteria;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -37,6 +38,6 @@ class PublicationSeeder extends Seeder
             'name' => 'CCR Test Publication 1',
         ]);
 
-        Publication::factory()->count(5)->create();
+        Publication::factory()->count(5)->has(StyleCriteria::factory()->count(4))->create();
     }
 }

--- a/backend/database/seeders/PublicationSeeder.php
+++ b/backend/database/seeders/PublicationSeeder.php
@@ -38,6 +38,12 @@ class PublicationSeeder extends Seeder
             'name' => 'CCR Test Publication 1',
         ]);
 
-        Publication::factory()->count(5)->has(StyleCriteria::factory()->count(4))->create();
+        Publication::factory()
+            ->count(5)
+            ->has(
+                StyleCriteria::factory()
+                    ->count(4)
+            )
+            ->create();
     }
 }

--- a/backend/database/seeders/PublicationSeeder.php
+++ b/backend/database/seeders/PublicationSeeder.php
@@ -13,21 +13,21 @@ class PublicationSeeder extends Seeder
     /**
      * Run the database seed and create a publication with an administrator and editor.
      *
-     * @param \App\Models\User $admin
-     * @param \App\Models\User $editor
      * @return void
      */
-    public function run(User $admin, User $editor)
+    public function run()
     {
+        $this->callOnce(UserSeeder::class);
+
         Publication::factory()
         ->hasAttached(
-            $admin,
+            User::firstWhere('username', 'publicationAdministrator'),
             [
                 'role_id' => Role::PUBLICATION_ADMINISTRATOR_ROLE_ID,
             ]
         )
         ->hasAttached(
-            $editor,
+            User::firstWhere('username', 'publicationEditor'),
             [
                 'role_id' => Role::EDITOR_ROLE_ID,
             ]
@@ -36,5 +36,7 @@ class PublicationSeeder extends Seeder
             'id' => 1,
             'name' => 'CCR Test Publication 1',
         ]);
+
+        Publication::factory()->count(5)->create();
     }
 }

--- a/backend/database/seeders/StyleCriteriasSeeder.php
+++ b/backend/database/seeders/StyleCriteriasSeeder.php
@@ -13,7 +13,7 @@ class StyleCriteriasSeeder extends Seeder
      */
     public function run()
     {
-        $style_criterias = collect([
+        $style_criterias = [
             [
                 'name' => 'Accessibility',
                 'description' => '<ul><li>Can the author replace or explain any technical terms?</li><li>How does ' .
@@ -49,8 +49,9 @@ class StyleCriteriasSeeder extends Seeder
                                  ' with the issue at hand?</li></ul>',
                 'icon' => 'question_answer',
             ],
-        ]);
-        $style_criterias->map(function ($criteria) {
+        ];
+
+        foreach ($style_criterias as $criteria) {
             StyleCriteria::factory()
                 ->create([
                     'name' => $criteria['name'],
@@ -58,6 +59,6 @@ class StyleCriteriasSeeder extends Seeder
                     'description' => $criteria['description'],
                     'icon' => $criteria['icon'],
                 ]);
-        });
+        }
     }
 }

--- a/backend/database/seeders/SubmissionFileSeeder.php
+++ b/backend/database/seeders/SubmissionFileSeeder.php
@@ -15,6 +15,8 @@ class SubmissionFileSeeder extends Seeder
      */
     public function run()
     {
+        $this->callOnce(SubmissionSeeder::class);
+
         SubmissionFile::factory()->count(2)->create([
             'submission_id' => 100,
         ]);

--- a/backend/database/seeders/SubmissionSeeder.php
+++ b/backend/database/seeders/SubmissionSeeder.php
@@ -17,25 +17,39 @@ class SubmissionSeeder extends Seeder
      * - Submitter: regularUser
      * - Review Coordinator: reviewCoordinator
      *
+     * @return void
+     */
+    public function run()
+    {
+        $this->callOnce(PublicationSeeder::class);
+        $this->callOnce(UserSeeder::class);
+
+        $this->createSubmission(100, 'CCR Test Submission 1');
+        $this->createSubmission(101, 'CCR Test Submission 2');
+    }
+
+    /**
+     * Create a submission
+     *
      * @param int $id
      * @param string $title
      * @return void
      */
-    public function run($id, $title)
+    protected function createSubmission($id, $title)
     {
         $submission = Submission::factory()
             ->hasAttached(
-                User::where('username', 'regularUser')->firstOrFail(),
+                User::firstWhere('username', 'regularUser'),
                 [],
                 'submitters'
             )
             ->hasAttached(
-                User::where('username', 'reviewCoordinator')->firstOrFail(),
+                User::firstWhere('username', 'reviewCoordinator'),
                 [],
                 'reviewCoordinators'
             )
             ->hasAttached(
-                User::where('username', 'reviewer')->firstOrFail(),
+                User::firstWhere('username', 'reviewer'),
                 [],
                 'reviewers'
             )
@@ -49,6 +63,7 @@ class SubmissionSeeder extends Seeder
             ]);
         $submission->updated_by = 2;
         $submission->content()->associate($submission->contentHistory->last())->save();
+        //TODO: Put this event on the model so it gets called no matter how the object is created.
         $event = new SubmissionCreated($submission);
         $listener = new NotifyUsersAboutCreatedSubmission();
         $listener->handle($event);

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        User::factory()->create([
+            'username' => 'applicationAdminUser',
+            'email' => 'applicationadministrator@ccrproject.dev',
+            'name' => 'Application Administrator',
+            'password' => Hash::make('adminPassword!@#'),
+        ])->assignRole(Role::APPLICATION_ADMINISTRATOR);
+
+        User::factory()->create([
+            'username' => 'publicationAdministrator',
+            'email' => 'publicationAdministrator@ccrproject.dev',
+            'name' => 'Publication Administrator',
+            'password' => Hash::make('publicationadminPassword!@#'),
+        ]);
+
+        User::factory()->create([
+            'username' => 'publicationEditor',
+            'email' => 'publicationEditor@ccrproject.dev',
+            'name' => 'Publication Editor',
+            'password' => Hash::make('editorPassword!@#'),
+        ]);
+
+        User::factory()->create([
+            'username' => 'reviewCoordinator',
+            'email' => 'reviewCoordinator@ccrproject.dev',
+            'name' => 'Review Coordinator for Submission',
+            'password' => Hash::make('coordinatorPassword!@#'),
+        ]);
+
+        User::factory()->create([
+            'username' => 'reviewer',
+            'email' => 'reviewer@ccrproject.dev',
+            'name' => 'Reviewer for Submission',
+            'password' => Hash::make('reviewerPassword!@#'),
+        ]);
+
+        User::factory()->create([
+            'username' => 'regularUser',
+            'email' => 'regularuser@ccrproject.dev',
+            'name' => 'Regular User',
+            'password' => Hash::make('regularPassword!@#'),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR makes each seeder perform independently by moving the creation of models inside the seeder classes and calling them from the database seeder (the default seeder called when none is specified).  Seeders now also use callOnce to call the models they are dependent on. This means that a seeder can be called on its own and will seed only the data needed for that seeder to complete.