### PR TITLE
fix(api): add missing method preventing migration:reset from succeeding

### DIFF
--- a/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
+++ b/backend/database/migrations/2021_06_01_195428_create_submissions_tables.php
@@ -62,7 +62,7 @@ class CreateSubmissionsTables extends Migration
         Schema::table('submissions', function (Blueprint $table) {
             $table->dropForeign('submissions_publication_id_foreign');
         });
-        Schema::dropIfExists('submissions_user');
+        Schema::dropIfExists('submission_user');
         Schema::dropIfExists('submissions');
     }
 }

--- a/backend/database/migrations/2022_02_14_202738_create_settings_table.php
+++ b/backend/database/migrations/2022_02_14_202738_create_settings_table.php
@@ -19,4 +19,12 @@ class CreateSettingsTable extends Migration
             $table->timestamps();
         });
     }
+
+    /**
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('settings');
+    }
 }


### PR DESCRIPTION
This pull request:

* Adds a missing down method for the `settings` table so that it can be removed properly when running a migration reset (`lando artisan migrate:reset`)
* Fixes a typo on a reference to the `submission_user` table so that it also gets removed properly when running a migration reset

Closes #1138 