### PR TITLE
feat: Add submission status to the submission details page

### DIFF
--- a/client/src/graphql/queries.js
+++ b/client/src/graphql/queries.js
@@ -163,6 +163,7 @@ export const GET_SUBMISSION = gql`
     submission(id: $id) {
       id
       title
+      status
       publication {
         name
         style_criterias {

--- a/client/src/i18n/en-US/index.js
+++ b/client/src/i18n/en-US/index.js
@@ -422,6 +422,21 @@ export default {
     },
   },
   submission: {
+    status: {
+      title: "Submission Status",
+      INITIALLY_SUBMITTED: "Initially Submitted",
+      AWAITING_RESUBMISSION: "Awaiting Resubmission",
+      RESUBMITTED: "Resubmitted",
+      AWAITING_REVIEW: "Awaiting Review",
+      REJECTED: "Rejected",
+      ACCEPTED_AS_FINAL: "Accepted as Final",
+      EXPIRED: "Expired",
+      UNDER_REVIEW: "Under Review",
+      AWAITING_DECISION: "Awaiting Decision",
+      AWAITING_REVISION: "Awaiting Revision",
+      ARCHIVED: "Archived",
+      DELETED: "Deleted",
+    },
     toolbar: {
       back: "Back to Submission Details",
       toggle_inline_comments: "Toggle Inline Comments",

--- a/client/src/pages/SubmissionDetails.vue
+++ b/client/src/pages/SubmissionDetails.vue
@@ -23,7 +23,7 @@
             icon="radio_button_checked"
             color="primary"
             text-color="white"
-            >{{ submission.status }}</q-chip
+            >{{ toTitleCase(submission.status) }}</q-chip
           >
         </div>
       </q-banner>
@@ -81,4 +81,9 @@ const { result } = useQuery(GET_SUBMISSION, { id: props.id })
 const submission = computed(() => {
   return result.value?.submission ?? null
 })
+const toTitleCase = (s) =>
+  s
+    .toLowerCase()
+    .replace(/^\w/, (c) => c.toUpperCase())
+    .replace(/[_]+(.)/g, (_, c) => " " + c.toUpperCase())
 </script>

--- a/client/src/pages/SubmissionDetails.vue
+++ b/client/src/pages/SubmissionDetails.vue
@@ -25,8 +25,9 @@
             icon="radio_button_checked"
             color="primary"
             text-color="white"
-            >{{ $t(`submission.status.${submission.status}`) }}</q-chip
           >
+            {{ $t(`submission.status.${submission.status}`) }}
+          </q-chip>
         </div>
       </q-banner>
     </section>

--- a/client/src/pages/SubmissionDetails.vue
+++ b/client/src/pages/SubmissionDetails.vue
@@ -16,14 +16,16 @@
     <section>
       <q-banner class="bg-grey-3">
         <div class="flex row items-center">
-          <h3 class="q-ml-sm q-mr-md text-h4">Submission Status</h3>
+          <h3 class="q-ml-sm q-mr-md text-h4">
+            {{ $t("submission.status.title") }}
+          </h3>
           <q-separator vertical />
           <q-chip
             class="q-ml-md"
             icon="radio_button_checked"
             color="primary"
             text-color="white"
-            >{{ toTitleCase(submission.status) }}</q-chip
+            >{{ $t(`submission.status.${submission.status}`) }}</q-chip
           >
         </div>
       </q-banner>
@@ -81,9 +83,4 @@ const { result } = useQuery(GET_SUBMISSION, { id: props.id })
 const submission = computed(() => {
   return result.value?.submission ?? null
 })
-const toTitleCase = (s) =>
-  s
-    .toLowerCase()
-    .replace(/^\w/, (c) => c.toUpperCase())
-    .replace(/[_]+(.)/g, (_, c) => " " + c.toUpperCase())
 </script>

--- a/client/src/pages/SubmissionDetails.vue
+++ b/client/src/pages/SubmissionDetails.vue
@@ -23,7 +23,7 @@
             icon="radio_button_checked"
             color="primary"
             text-color="white"
-            >Initially Submitted</q-chip
+            >{{ submission.status }}</q-chip
           >
         </div>
       </q-banner>

--- a/client/src/pages/SubmissionDetails.vue
+++ b/client/src/pages/SubmissionDetails.vue
@@ -13,6 +13,21 @@
       </q-breadcrumbs>
     </nav>
     <h2 class="q-pl-lg">{{ submission.title }}</h2>
+    <section>
+      <q-banner class="bg-grey-3">
+        <div class="flex row items-center">
+          <h3 class="q-ml-sm q-mr-md text-h4">Submission Status</h3>
+          <q-separator vertical />
+          <q-chip
+            class="q-ml-md"
+            icon="radio_button_checked"
+            color="primary"
+            text-color="white"
+            >Initially Submitted</q-chip
+          >
+        </div>
+      </q-banner>
+    </section>
     <div class="row q-col-gutter-lg q-pa-lg">
       <section class="col-12">
         <q-btn


### PR DESCRIPTION
This PR adds Quasar components to the Submission Details page for displaying an i18n-translated status label based on the database-derived status of the viewed submission.

Closes #1254 