### PR TITLE
docs: Add migration and seeding instructions

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -48,6 +48,8 @@ You can then open a browser to <https://ccr.lndo.site/> and view the project run
 
 By default, the database of the application will be empty. To log in as a sample user, the database tables must be [migrated](https://laravel.com/docs/master/migrations) and [seeded](https://laravel.com/docs/master/seeding#main-content).
 
+The commands to migrate and seed will need to be ran each time a new migration or seed is added to the repository.
+
 #### Migrate and Seed
 
 `lando artisan migrate:fresh --seed`

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -44,6 +44,25 @@ Lando will then download the appropriate containers and get everything spun up. 
 
 You can then open a browser to <https://ccr.lndo.site/> and view the project running on your local machine.
 
+### Database Migration and Seeding
+
+By default, the database of the application will be empty. To log in as a sample user, the database tables must be [migrated](https://laravel.com/docs/master/migrations) and [seeded](https://laravel.com/docs/master/seeding#main-content).
+
+#### Migrate and Seed
+
+`lando artisan migrate:fresh --seed`
+
+#### Migrate Only
+
+`lando artisan migrate:fresh`
+
+#### Seed Only
+
+`lando artisan db:seed`
+
+
+Once seeding is complete, you can log in at <https://ccr.lndo.site/login> as any one of the sample users defined in `backend/database/seeders/UserSeeder.php` in the repository.
+
 ### Lando tooling commands
 
 Lando has built-in tooling commands that allow a developer to run commands inside a container from their terminal.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -54,7 +54,7 @@ The commands to migrate and seed will need to be ran each time a new migration o
 
 `lando artisan migrate:fresh --seed`
 
-`:fresh` clears the database and then runs migrations. `--seed` will run the seeders after migrations complete.
+`:fresh` drops all tables in the database and then runs migrations. `--seed` will run the seeders after migrations complete.
 
 #### Migrate Only
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -62,7 +62,6 @@ The commands to migrate and seed will need to be ran each time a new migration o
 
 `lando artisan db:seed`
 
-
 Once seeding is complete, you can log in at <https://ccr.lndo.site/login> as any one of the sample users defined in `backend/database/seeders/UserSeeder.php` in the repository.
 
 ### Lando tooling commands

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -54,6 +54,8 @@ The commands to migrate and seed will need to be ran each time a new migration o
 
 `lando artisan migrate:fresh --seed`
 
+`:fresh` clears the database and then runs migrations. `--seed` will run the seeders after migrations complete.
+
 #### Migrate Only
 
 `lando artisan migrate:fresh`


### PR DESCRIPTION
This pull request adds instructions for migrating and seeding the database, which resolves a missing part of the documentation that would help a developer unfamiliar with the application understand how they can log in to the application on the client. 

Closes #1276 