### PR TITLE
docs: Add introduction to the Guide page of the documentation site

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-CCR is a new application that facilitates values-based open peer review for scholarly communications.
+The Collaborative Community Review (CCR) is a new application that facilitates values-based open peer review for scholarly communications.
 
 The defining feature of CCR is its focus on collaborative, values-based dialogue around a submission in lieu of traditional peer review. After an article is submitted, editorial teams can invite reviewers to have an asynchronous discussion with the text and author in which each comment is associated with at least one of a set of values defined by the publication. For the Public Philosophy Journal, these values include accessibility, relevance, intellectual coherence, and scholarly dialogue. CCR allows publications to define their own sets of values.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,5 +1,11 @@
 # Introduction
 
-Somewhere around here is where you'll eventually find information about using CCR as a user/contributor, etc.
+Pilcrow is a new application that facilitates values-based open peer review for scholarly communications.
+
+The defining feature of Pilcrow is its focus on collaborative, values-based dialogue around a submission in lieu of traditional peer review. After an article is submitted, editorial teams can invite reviewers to have an asynchronous discussion with the text and author in which each comment is associated with at least one of a set of values defined by the publication. For the Public Philosophy Journal, these values include accessibility, relevance, intellectual coherence, and scholarly dialogue. Pilcrow allows publications to define their own sets of values.
+
+This structure enables editorial teams to develop an inclusive and supportive space in which ideas are explored and refined collaboratively. By facilitating a more collegial and thoughtful peer review process, Pilcrow aims to better both scholarship and the processes used to create it. Pilcrow also provides editorial teams with a full review process flow, allowing them to move a piece of scholarship from submission through peer review and export it for publication. Editorial teams can also invite, manage, and correspond with authors and reviewers.
+
+Pilcrow is funded by Mellon Grant #XYZ. More on the Public Philsophy Journal and our ongoing work can be found here: LINK.
 
 (noticeable change)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -6,4 +6,4 @@ The defining feature of CCR is its focus on collaborative, values-based dialogue
 
 This structure enables editorial teams to develop an inclusive and supportive space in which ideas are explored and refined collaboratively. By facilitating a more collegial and thoughtful peer review process, CCR aims to better both scholarship and the processes used to create it. CCR also provides editorial teams with a full review process flow, allowing them to move a piece of scholarship from submission through peer review and export it for publication. Editorial teams can also invite, manage, and correspond with authors and reviewers.
 
-CCR is funded by Mellon. More on the Public Philsophy Journal and our ongoing work can be found here: <https://publicphilosophyjournal.org/about/mission-vision-values/>
+CCR is funded by Mellon Foundation. More on the Public Philosophy Journal and our ongoing work can be found here: <https://publicphilosophyjournal.org/about/mission-vision-values/>

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,9 +1,9 @@
 # Introduction
 
-Pilcrow is a new application that facilitates values-based open peer review for scholarly communications.
+CCR is a new application that facilitates values-based open peer review for scholarly communications.
 
-The defining feature of Pilcrow is its focus on collaborative, values-based dialogue around a submission in lieu of traditional peer review. After an article is submitted, editorial teams can invite reviewers to have an asynchronous discussion with the text and author in which each comment is associated with at least one of a set of values defined by the publication. For the Public Philosophy Journal, these values include accessibility, relevance, intellectual coherence, and scholarly dialogue. Pilcrow allows publications to define their own sets of values.
+The defining feature of CCR is its focus on collaborative, values-based dialogue around a submission in lieu of traditional peer review. After an article is submitted, editorial teams can invite reviewers to have an asynchronous discussion with the text and author in which each comment is associated with at least one of a set of values defined by the publication. For the Public Philosophy Journal, these values include accessibility, relevance, intellectual coherence, and scholarly dialogue. CCR allows publications to define their own sets of values.
 
-This structure enables editorial teams to develop an inclusive and supportive space in which ideas are explored and refined collaboratively. By facilitating a more collegial and thoughtful peer review process, Pilcrow aims to better both scholarship and the processes used to create it. Pilcrow also provides editorial teams with a full review process flow, allowing them to move a piece of scholarship from submission through peer review and export it for publication. Editorial teams can also invite, manage, and correspond with authors and reviewers.
+This structure enables editorial teams to develop an inclusive and supportive space in which ideas are explored and refined collaboratively. By facilitating a more collegial and thoughtful peer review process, CCR aims to better both scholarship and the processes used to create it. CCR also provides editorial teams with a full review process flow, allowing them to move a piece of scholarship from submission through peer review and export it for publication. Editorial teams can also invite, manage, and correspond with authors and reviewers.
 
-Pilcrow is funded by Mellon Grant #XYZ. More on the Public Philsophy Journal and our ongoing work can be found here: LINK.
+CCR is funded by Mellon. More on the Public Philsophy Journal and our ongoing work can be found here: <https://publicphilosophyjournal.org/about/mission-vision-values/>

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -7,5 +7,3 @@ The defining feature of Pilcrow is its focus on collaborative, values-based dial
 This structure enables editorial teams to develop an inclusive and supportive space in which ideas are explored and refined collaboratively. By facilitating a more collegial and thoughtful peer review process, Pilcrow aims to better both scholarship and the processes used to create it. Pilcrow also provides editorial teams with a full review process flow, allowing them to move a piece of scholarship from submission through peer review and export it for publication. Editorial teams can also invite, manage, and correspond with authors and reviewers.
 
 Pilcrow is funded by Mellon Grant #XYZ. More on the Public Philsophy Journal and our ongoing work can be found here: LINK.
-
-(noticeable change)


### PR DESCRIPTION
This pull request adds the introduction to the Guide page as drafted by Shelby Brewster and Stephanie Vasko with some modifications as agreed upon by the development team:

* Replaces occurrences of 'Pilcrow' with 'CCR'
* Removes the reference to a specific grant number
* Adds a link to a page on PPJ's website


Closes #1055 