### PR TITLE
build: update configuration for staging deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: deploy to production
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Reclaim Cloud
+        uses: appleboy/ssh-action@master
+        with:
+          script: |
+            cd ccr-staging
+            redeploy.sh
+          host: ${{ secrets.STAGING_HOST }}
+          port: ${{ secrets.STAGING_PORT }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.PRIVATE_KEY}}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM php:8.0-fpm
 
 
@@ -15,9 +14,12 @@ RUN curl --silent --show-error https://getcomposer.org/installer | php && \
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
 RUN chmod +x /wait
 
-WORKDIR /var/www/html
-COPY . .
-RUN chown -R www-data:www-data /var/www/html
+ADD https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb /tmp/pandoc.deb
+RUN dpkg -i /tmp/pandoc.deb && rm /tmp/pandoc.deb
 
-RUN chmod +x .docker/* && cp .docker/* /usr/local/bin
+WORKDIR /var/www/html
+COPY --chown=www-data:www-data . .
+USER www-data:www-data
+RUN composer install --no-dev
+RUN chmod +x artisan
 

--- a/client/.docker/default.conf.template
+++ b/client/.docker/default.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 8888 default_server;
     server_name _;
     root /var/www/html;
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,4 @@
 version: '3'
-
-networks:
-  backend:
 services:
   client:
     build:
@@ -10,8 +7,8 @@ services:
     depends_on:
       - phpfpm
       - mysql
-    networks:
-      - backend
+    expose:
+      - 8888
   phpfpm:
     env_file:
       - .env
@@ -20,8 +17,6 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    networks:
-      - backend
     depends_on:
       - mysql
   mysql:
@@ -34,5 +29,4 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
       SERVICE_TAGS: dev
       SERVICE_NAME: mysql
-    networks:
-      - backend
+


### PR DESCRIPTION
Add script to deploy staging environment and adjust some issues with docker configuration.

* Test environment will be available at https://staging.ccrproject.dev
* Development seeders and migrate:fresh are run whenever master is updated.
* See [UserSeeder](https://github.com/MESH-Research/CCR/blob/master/backend/database/seeders/UserSeeder.php) for usernames and passwords available for login.
* All outgoing email is captured and redirected to https://mailhog.ccrproject.dev

closes #1332 