### PR TITLE
build: fix missing library in staging build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm
 
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git zip unzip libzip-dev libnuma1 libaio1 && \
+    apt-get install -y --no-install-recommends git zip unzip libzip-dev libnuma1 libaio1 libncurses6 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pdo_mysql zip


### PR DESCRIPTION
Fixes a missing library in the build for the php container preventing the build from successfully completing.