### PR TITLE
fix(client): update deep selectors in comment reply quotes (deprecation)

### DIFF
--- a/client/src/components/atoms/InlineCommentReply.vue
+++ b/client/src/components/atoms/InlineCommentReply.vue
@@ -62,7 +62,7 @@ div.active
   > .q-card__section:first-child
     background-color: #edf0c6 !important
 
-div::v-deep blockquote
+div :deep(blockquote)
   border-left: 4px solid #888888
   margin-inline-start: 1em
   padding-left: 0.5em

--- a/client/src/components/atoms/OverallCommentReply.vue
+++ b/client/src/components/atoms/OverallCommentReply.vue
@@ -64,7 +64,7 @@ div.active
   > .q-card__section:first-child
     background-color: #edf0c6 !important
 
-div::v-deep blockquote
+div :deep(blockquote)
   border-left: 4px solid #888888
   margin-inline-start: 1em
   padding-left: 0.5em


### PR DESCRIPTION
Fixes warning generated during a client build: `[@vue/compiler-sfc] ::v-deep usage as a combinator has been deprecated. Use :deep(<inner-selector>) instead.`