### PR TITLE
test: fix error message about incorrect args

### DIFF
--- a/client/test/cypress/plugins/index.js
+++ b/client/test/cypress/plugins/index.js
@@ -61,7 +61,7 @@ module.exports = (on, config) => {
     if (browser.family === "firefox") {
       launchOptions.preferences["ui.prefersReducedMotion"] = REDUCE
     }
-    if (browser.family === "chromium") {
+    if (browser.family === "chromium" && browser.name !== "electron") {
       launchOptions.args.push("--force-prefers-reduced-motion")
     }
     return launchOptions


### PR DESCRIPTION
Fixes the following error message that appears when running cypress at the command line.

![image](https://user-images.githubusercontent.com/463159/197040528-413eeb42-bfb8-4fc1-abb2-0458aa310710.png)
